### PR TITLE
JSON-RPC to graphql migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 .env
 /scripts/**/*.js
 /scripts/.env
+/scripts/snapshots/
 client_id
 settings.dat
 pending/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ shapes and are marked `@deprecated`; a new GraphQL-native
 `multiGetObjectsGraphql(ids)` helper is available for new code. See
 [STSUI_GRAPHQL_MIGRATION.md](STSUI_GRAPHQL_MIGRATION.md) for the
 field-by-field mapping. Override the GraphQL endpoint via the new
-`setGraphQLUrl(url)` helper.
+`setGraphQLUrl(url)` helper. By default, GraphQL follows the active SDK
+config network (`production` -> mainnet GraphQL, `testing` -> testnet
+GraphQL).
 
 ## How to create your own liquid staking token
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ npm i @stsui-sdk
 
 Internal Sui reads have moved from JSON-RPC to GraphQL. The public
 class/function APIs (`LST`, `Admin`, `Utils`, `Events`, `mint`,
-`redeem`, `refresh`, etc.) are unchanged. Two breaking type-shape
-changes affect direct consumers of `LiquidStakingInfo` / `Meta` and
-`getMultiObjects`. See [STSUI_GRAPHQL_MIGRATION.md](STSUI_GRAPHQL_MIGRATION.md)
-for the field-by-field mapping. Override the GraphQL endpoint via the
-new `setGraphQLUrl(url)` helper.
+`redeem`, `refresh`, etc.) are unchanged. The only breaking type-shape
+change affects direct consumers of `LiquidStakingInfo` / `Meta`, which
+are now flat (no `content.fields.*` wrapping). The legacy JSON-RPC
+helpers (`getMultiObjects`, `getSuiClient`, etc.) keep their original
+shapes and are marked `@deprecated`; a new GraphQL-native
+`multiGetObjectsGraphql(ids)` helper is available for new code. See
+[STSUI_GRAPHQL_MIGRATION.md](STSUI_GRAPHQL_MIGRATION.md) for the
+field-by-field mapping. Override the GraphQL endpoint via the new
+`setGraphQLUrl(url)` helper.
 
 ## How to create your own liquid staking token
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 npm i @stsui-sdk
 ```
 
+## v0.1.x — GraphQL migration
+
+Internal Sui reads have moved from JSON-RPC to GraphQL. The public
+class/function APIs (`LST`, `Admin`, `Utils`, `Events`, `mint`,
+`redeem`, `refresh`, etc.) are unchanged. Two breaking type-shape
+changes affect direct consumers of `LiquidStakingInfo` / `Meta` and
+`getMultiObjects`. See [STSUI_GRAPHQL_MIGRATION.md](STSUI_GRAPHQL_MIGRATION.md)
+for the field-by-field mapping. Override the GraphQL endpoint via the
+new `setGraphQLUrl(url)` helper.
+
 ## How to create your own liquid staking token
 
 - Write a simple contract to create a coin that will also represent your liquid staking token, stSUI for example.

--- a/STSUI_GRAPHQL_MIGRATION.md
+++ b/STSUI_GRAPHQL_MIGRATION.md
@@ -2,7 +2,11 @@
 
 `v0.1.x` of `@alphafi/stsui-sdk` migrates every internal Sui read from
 JSON-RPC to GraphQL. The public function/class signatures are unchanged
-except for **two breaking type-shape changes** documented below.
+except for **one breaking type-shape change** (the flat
+`LiquidStakingInfo` / `Meta` shapes documented below). All other
+JSON-RPC-shaped helpers, including `getMultiObjects`, retain their
+original return types and are merely marked `@deprecated`; new
+GraphQL-native variants are introduced under separate names.
 
 ## What changed
 
@@ -50,13 +54,25 @@ If you imported `LiquidStakingInfo` or `Meta` directly and navigated
 those fields, you'll need to drop the `.content` and intermediate
 `.fields` segments.
 
-### Breaking: `getMultiObjects` returns flat objects
+### Deprecated: `getMultiObjects` (kept for backward compatibility)
 
-`getMultiObjects({ ids })` previously returned `SuiObjectResponse[]`
-(JSON-RPC shape). It now returns `(FlatObject | null)[]` where
-`FlatObject` is `{ objectId, version, digest, type, fields }`. The
-`options` parameter is preserved for source compatibility but ignored —
-GraphQL always includes contents.
+`getMultiObjects({ ids, options })` continues to return
+`SuiObjectResponse[]` via JSON-RPC and is now marked `@deprecated`.
+Existing callers do not need any changes.
+
+For new code, prefer the GraphQL-native helper:
+
+```ts
+import { multiGetObjectsGraphql, FlatObject } from "@alphafi/stsui-sdk";
+
+const objects: (FlatObject | null)[] = await multiGetObjectsGraphql([
+  lstInfoId,
+  metaObjectId,
+]);
+```
+
+`FlatObject` is `{ objectId, version, digest, type, fields }`. Use
+`fields` directly (no `content.fields.*` wrapping).
 
 ### Fixed: `getWalletCoins` was returning `[]`
 

--- a/STSUI_GRAPHQL_MIGRATION.md
+++ b/STSUI_GRAPHQL_MIGRATION.md
@@ -1,0 +1,94 @@
+# stSUI SDK GraphQL migration
+
+`v0.1.x` of `@alphafi/stsui-sdk` migrates every internal Sui read from
+JSON-RPC to GraphQL. The public function/class signatures are unchanged
+except for **two breaking type-shape changes** documented below.
+
+## What changed
+
+### Internal: JSON-RPC → GraphQL
+
+The SDK no longer issues `SuiClient.getObject`, `getCoins`,
+`getAllCoins`, `getAllBalances`, `queryEvents`, or
+`getLatestSuiSystemState` calls. All reads now go through a
+`SuiGraphQLClient` singleton in [`src/common/graphql.ts`](src/common/graphql.ts).
+Typed read primitives live in [`src/common/blockchain.ts`](src/common/blockchain.ts).
+
+The legacy `SuiClient` accessors (`getSuiClient`, `setSuiNodeUrl`,
+`setSuiClient`, `setCustomSuiClient`) are kept for backward compatibility
+but marked `@deprecated`. The internal SuiClient is still used for
+`Transaction.build()` resolution; consumers can also still grab a
+SuiClient if they want to sign/execute transactions themselves.
+
+A new pair of singletons is added for the GraphQL endpoint:
+
+```ts
+import { getGraphQLClient, setGraphQLUrl } from "@alphafi/stsui-sdk";
+setGraphQLUrl("https://my-graphql-proxy.example.com/graphql");
+```
+
+### Breaking: `LiquidStakingInfo` and `Meta` are now flat
+
+The legacy JSON-RPC `getObject({showContent: true})` shape wrapped every
+nested Move struct in `{ type, fields }`. The new flat shape drops those
+wrappers (and the JSON-RPC `id: { id: string }` UID encoding):
+
+| Old (`v0.0.x`)                                                               | New (`v0.1.x`)                                         |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `lstInfo.content.fields.storage.fields.total_sui_supply`                     | `lstInfo.fields.storage.total_sui_supply`              |
+| `lstInfo.content.fields.lst_treasury_cap.fields.total_supply.fields.value`   | `lstInfo.fields.lst_treasury_cap.total_supply.value`   |
+| `lstInfo.content.fields.accrued_spread_fees`                                 | `lstInfo.fields.accrued_spread_fees`                   |
+| `lstInfo.content.fields.fee_config.fields.element.fields.<FeeConfig fields>` | `lstInfo.fields.fee_config.element.<FeeConfig fields>` |
+| `meta.content.fields.stakers.fields.size`                                    | `meta.fields.stakers.size`                             |
+| `meta.content.fields.last_update_event_timestamp`                            | `meta.fields.last_update_event_timestamp`              |
+
+The top-level `objectId / version / digest` fields are unchanged. A new
+`type: string` field is exposed at the top level (the Move type that was
+previously at `content.type`).
+
+If you imported `LiquidStakingInfo` or `Meta` directly and navigated
+those fields, you'll need to drop the `.content` and intermediate
+`.fields` segments.
+
+### Breaking: `getMultiObjects` returns flat objects
+
+`getMultiObjects({ ids })` previously returned `SuiObjectResponse[]`
+(JSON-RPC shape). It now returns `(FlatObject | null)[]` where
+`FlatObject` is `{ objectId, version, digest, type, fields }`. The
+`options` parameter is preserved for source compatibility but ignored —
+GraphQL always includes contents.
+
+### Fixed: `getWalletCoins` was returning `[]`
+
+The pre-migration implementation of `getWalletCoins(owner)` accumulated
+coin types into a local variable but never populated the returned
+`coins[]` array — it always returned `[]`. The GraphQL rewrite returns
+the actual coin list (one entry per unique coin type owned).
+
+## What didn't change
+
+- `LST.mint / redeem / refresh`, `Admin.createLst / collectFee /
+updateFee / setValidators`, `Utils.*`, and all free transaction
+  builders take the same arguments and return the same `Transaction`.
+- `Events.getMintEvents / getRedeemEvents / getEpochChangeEvents /
+getFlashStakeEvents` keep the same parameter and return shapes.
+- `getBalances / getAllBalances` keep returning `{ tokenName, balance }[]`.
+- `stSuiExchangeRate / stStuiCirculationSupply / fetchTotalSuiStaked /
+fetchCurrentStSuiEpoch / fetchStSuiAPR / fetchStSuiAPY /
+fetchTotalStakers / getFees` return the same primitive types they did
+  before.
+
+## Validation
+
+The migration was validated end-to-end with a snapshot harness
+(`scripts/migration-snapshot.ts` + `scripts/migration-diff.ts`). After
+classifying noise (accruing chain accumulators, oracle prices, event
+timestamps) and the one expected fix (`getWalletCoins`), the diff
+between pre- and post-migration captures shows **0 signal differences**
+across 42 captures covering every public read and transaction builder.
+
+## Endpoints
+
+The default GraphQL URL is `https://graphql.mainnet.sui.io/graphql`.
+Override with `setGraphQLUrl(url)` if you point at a private proxy or a
+non-mainnet network.

--- a/__tests__/getExchangeRate.test.ts
+++ b/__tests__/getExchangeRate.test.ts
@@ -1,8 +1,8 @@
-import { stSuiExchangeRate } from "..";
+import { getConf, stSuiExchangeRate } from "..";
 
 describe("stSuiExchangeRate", () => {
   it("should return the correct value", async () => {
-    return stSuiExchangeRate().then((exchangeRate) => {
+    return stSuiExchangeRate(getConf().LST_INFO, true).then((exchangeRate) => {
       expect(exchangeRate).toBeDefined();
     });
   });

--- a/__tests__/getTVL.test.ts
+++ b/__tests__/getTVL.test.ts
@@ -1,8 +1,8 @@
-import { stStuiCirculationSupply } from "..";
+import { getConf, stStuiCirculationSupply } from "..";
 
-describe("fetchStSuiAPR", () => {
+describe("stStuiCirculationSupply", () => {
   it("should return the correct value", async () => {
-    return stStuiCirculationSupply().then((tvl) => {
+    return stStuiCirculationSupply(getConf().LST_INFO, true).then((tvl) => {
       expect(tvl).toBeDefined();
     });
   });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import tseslint from "typescript-eslint";
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
-  { languageOptions: { globals: globals.browser } },
+  { languageOptions: { globals: globals.node } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,6 @@
 import globals from "globals";
 import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
-import pluginReact from "eslint-plugin-react";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -9,5 +8,4 @@ export default [
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
-  pluginReact.configs.flat.recommended,
 ];

--- a/jest.config.cjs.js
+++ b/jest.config.cjs.js
@@ -2,6 +2,8 @@ export default {
   preset: "ts-jest",
   testEnvironment: "node",
   rootDir: "__tests__", // root directory for Jest
+  // Integration tests hit mainnet via GraphQL / Pyth — give them headroom.
+  testTimeout: 60000,
   transform: {
     "^.+\\.ts$": [
       "ts-jest",

--- a/jest.config.esm.js
+++ b/jest.config.esm.js
@@ -3,6 +3,8 @@ export default {
   testEnvironment: "node",
   rootDir: "__tests__", // root directory for Jest
   extensionsToTreatAsEsm: [".ts"], // Treat TypeScript files as ESM
+  // Integration tests hit mainnet via GraphQL / Pyth — give them headroom.
+  testTimeout: 60000,
   transform: {
     "^.+\\.ts$": [
       "ts-jest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.12.tgz",
       "integrity": "sha512-BTDjjsV/zSPy5fqItwm+KWUfh9CSe9tTtR6rCB72ddtkAxdcHbi4Ir4r/L1Et4lyxmL+i7Rb3m9sjLLi9tYrzA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
@@ -50,6 +51,7 @@
       "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.12.16.tgz",
       "integrity": "sha512-B5pyYVH93Etv7xjT6IfB7QtMBdaaC07yjbhN6v8H7KgFStMkPvi+oWYBTibMFRMY89qwc9H8YixXg8SXDVgYWw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@gql.tada/internal": "^1.0.0",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
@@ -100,7 +102,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -690,6 +691,7 @@
       "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.6.3.tgz",
       "integrity": "sha512-jFFSY8OxYeBxdKi58UzeMXG1tdm4FVjXa8WHIi66Gzu9JWtCE6mqom3a8xkmSw+mVaybFW5EN2WXf1WztJVNyQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@0no-co/graphqlsp": "^1.12.13",
         "@gql.tada/internal": "1.0.8",
@@ -716,6 +718,7 @@
       "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.8.tgz",
       "integrity": "sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5"
       },
@@ -729,6 +732,7 @@
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
       "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
@@ -1238,6 +1242,7 @@
       "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.4.0.tgz",
       "integrity": "sha512-YwDYspceLt8b7v6ohPvy8flQEi+smtfSG5d2A98CbUA48XBmOqTSPNmpw9wsZVVnrH2avr+BS5uVhDZT+EquYA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bs58": "^6.0.0"
       }
@@ -1272,6 +1277,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
       "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.7.0"
       },
@@ -1287,6 +1293,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
       "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1350,6 +1357,7 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
       "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -1359,6 +1367,7 @@
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.1.tgz",
       "integrity": "sha512-jSO+5Ud1E588Y+LFo8TaB8JVPNAZw/lGGao+1SepHDeTs2dFLurdNIAgUuDlwezqEjRjElkCJajVrtrZaBxvaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.8.0",
         "@noble/hashes": "~1.7.0",
@@ -1373,6 +1382,7 @@
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.1.tgz",
       "integrity": "sha512-GnlufVSP9UdAo/H2Patfv22VTtpNTyfi+I3qCKpvuB5l1KWzEYx+l2TNpBy9Ksh4xTs3Rn06tBlpWCi/1Vz8gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.7.0",
         "@scure/base": "~1.2.1"
@@ -1435,7 +1445,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@suchipi/femver/-/femver-1.0.0.tgz",
       "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1626,7 +1637,6 @@
       "integrity": "sha512-6M8taKyOETY1TKHp0x8ndycipTVgmp4xtg5QpEZzXxDhNvvHOJi5rLRkLr8SK3jTgD5l4fTlvBiRdfsuWydxBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.19.0",
         "@typescript-eslint/types": "8.19.0",
@@ -1816,7 +1826,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2187,13 +2196,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
       "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2236,7 +2247,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2267,6 +2277,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
       "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base-x": "^5.0.0"
       }
@@ -2963,7 +2974,6 @@
       "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3024,7 +3034,6 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3667,6 +3676,7 @@
       "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.10.tgz",
       "integrity": "sha512-FrvSxgz838FYVPgZHGOSgbpOjhR+yq44rCzww3oOPJYi0OvBJjAgCiP6LEokZIYND2fUTXzQAyLgcvgw1yNP5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
         "@0no-co/graphqlsp": "^1.12.13",
@@ -4441,7 +4451,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5029,6 +5038,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
       "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5769,7 +5779,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.2.1.tgz",
       "integrity": "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
@@ -6847,7 +6858,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6968,7 +6978,8 @@
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.36.0.tgz",
       "integrity": "sha512-CjF1XN4sUce8sBK9TixrDqFM7RwNkuXdJu174/AwmQUB62QbCQADg5lLe8ldBalFgtj1uKj+pKwDJiNo4Mn+eQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "eslint": "^9.14.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
-        "eslint-plugin-react": "^7.37.2",
         "globals": "^15.12.0",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.14.0"
@@ -1918,163 +1917,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/array-buffer-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "is-array-buffer": "^3.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-includes": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
-      "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.findlast": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
-      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
-      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flatmap": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
-      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.tosorted": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
-      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
-        "es-errors": "^1.3.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
-      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "is-array-buffer": "^3.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2297,56 +2144,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2526,60 +2323,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-view-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
-      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/data-view-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
-      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/inspect-js"
-      }
-    },
-    "node_modules/data-view-byte-offset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
-      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -2633,42 +2376,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2685,34 +2392,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/ejs": {
@@ -2773,177 +2452,6 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-abstract": {
-      "version": "1.23.9",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
-      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.2",
-        "arraybuffer.prototype.slice": "^1.0.4",
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "data-view-buffer": "^1.0.2",
-        "data-view-byte-length": "^1.0.2",
-        "data-view-byte-offset": "^1.0.1",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-set-tostringtag": "^2.1.0",
-        "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.0",
-        "get-symbol-description": "^1.1.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "internal-slot": "^1.1.0",
-        "is-array-buffer": "^3.0.5",
-        "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.2",
-        "is-regex": "^1.2.1",
-        "is-shared-array-buffer": "^1.0.4",
-        "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.0",
-        "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.3",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.7",
-        "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.3",
-        "safe-array-concat": "^1.1.3",
-        "safe-push-apply": "^1.0.0",
-        "safe-regex-test": "^1.1.0",
-        "set-proto": "^1.0.0",
-        "string.prototype.trim": "^1.2.10",
-        "string.prototype.trimend": "^1.0.9",
-        "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-length": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4",
-        "typed-array-length": "^1.0.7",
-        "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.18"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-iterator-helpers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
-      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
-        "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.0.3",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.6",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "iterator.prototype": "^1.1.4",
-        "safe-array-concat": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-shim-unscopables": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
-      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.0"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
@@ -3070,39 +2578,6 @@
         "eslint-config-prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-react": {
-      "version": "7.37.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.3.tgz",
-      "integrity": "sha512-DomWuTQPFYZwF/7c9W2fkKkStqZmBd3uugfqBYLdkZ3Hii23WzZuOLUskGxB8qkSKqftxEeGL1TB2kMhrce0jA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.8",
-        "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.3",
-        "array.prototype.tosorted": "^1.1.4",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.2.1",
-        "estraverse": "^5.3.0",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.8",
-        "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.5",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.12",
-        "string.prototype.repeat": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
     "node_modules/eslint-scope": {
@@ -3428,16 +2903,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3467,37 +2932,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3516,31 +2950,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3548,20 +2957,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3574,24 +2969,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-symbol-description": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
-      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -3641,36 +3018,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globalthis": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gql.tada": {
       "version": "1.8.10",
       "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.10.tgz",
@@ -3714,19 +3061,6 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
-    "node_modules/has-bigints": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3734,64 +3068,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
-      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -3893,109 +3169,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/internal-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/is-array-buffer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
-    },
-    "node_modules/is-async-function": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
-      "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-bigint": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-bigints": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-boolean-object": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -4012,41 +3190,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-data-view": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
-      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "is-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4055,22 +3198,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-finalizationregistry": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
-      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -4091,25 +3218,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4123,19 +3231,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4143,71 +3238,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-number-object": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-set": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -4221,110 +3251,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-string": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakmap": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
-      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakset": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4408,24 +3334,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/iterator.prototype": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
-      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "get-proto": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/jake": {
@@ -5113,22 +4021,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsx-ast-utils": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
-      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flat": "^1.3.1",
-        "object.assign": "^4.1.4",
-        "object.values": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5215,19 +4107,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5300,16 +4179,6 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/mdurl": {
@@ -5413,113 +4282,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
-      "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.fromentries": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
-      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.values": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
-      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5560,24 +4322,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.6",
-        "object-keys": "^1.1.1",
-        "safe-push-apply": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -5782,16 +4526,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5871,25 +4605,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5952,50 +4667,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
-    "node_modules/reflect.getprototypeof": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
-      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.1",
-        "which-builtin-type": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6003,24 +4674,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -6098,61 +4751,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "has-symbols": "^1.1.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-push-apply": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
-      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -6160,55 +4758,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-function-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
-      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -6230,82 +4779,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6400,104 +4873,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string.prototype.matchall": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
-      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "regexp.prototype.flags": "^1.5.3",
-        "set-function-name": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.repeat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
-      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
-    "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -6729,84 +5104,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/typed-array-byte-length": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
-      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-byte-offset": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
-      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.15",
-        "reflect.getprototypeof": "^1.0.9"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/typedoc": {
       "version": "0.27.6",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.6.tgz",
@@ -6894,25 +5191,6 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
-    },
-    "node_modules/unbox-primitive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
-      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "which-boxed-primitive": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/undici-types": {
       "version": "6.20.0",
@@ -7003,94 +5281,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-boxed-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.1",
-        "is-number-object": "^1.1.1",
-        "is-string": "^1.1.1",
-        "is-symbol": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-builtin-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
-      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "function.prototype.name": "^1.1.6",
-        "has-tostringtag": "^1.0.2",
-        "is-async-function": "^2.0.0",
-        "is-date-object": "^1.1.0",
-        "is-finalizationregistry": "^1.1.0",
-        "is-generator-function": "^1.0.10",
-        "is-regex": "^1.2.1",
-        "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.1.0",
-        "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-collection": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-map": "^2.0.3",
-        "is-set": "^2.0.3",
-        "is-weakmap": "^2.0.2",
-        "is-weakset": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint": "^9.14.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-react": "^7.37.2",
     "globals": "^15.12.0",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.14.0"

--- a/scripts/migration-diff.ts
+++ b/scripts/migration-diff.ts
@@ -60,6 +60,14 @@ const NOISE_SUFFIXES = new Set<string>([
   "totalBalance",
   "balance",
   "coinObjectCount",
+  // validator stake accumulators inside getMultiObjects(LST_INFO) projections
+  "pool_token_amount",
+  "sui_amount",
+  "inactive_stake",
+  "active_stake",
+  "extra_sui_amount",
+  "rewards_pool",
+  "validator_infos",
   // pyth (live oracle)
   "price",
   // event-window noise

--- a/scripts/migration-diff.ts
+++ b/scripts/migration-diff.ts
@@ -1,0 +1,321 @@
+/**
+ * Migration Diff (stsui-sdk)
+ *
+ * Compares the JSON snapshots under
+ *   scripts/snapshots/before/   (captured pre-migration)
+ *   scripts/snapshots/after/    (captured post-migration)
+ *
+ * Reports semantic differences in three buckets:
+ *   - signal    -> potential regression
+ *   - expected  -> intentional shape change documented in the migration
+ *   - noise     -> values that legitimately drift between two runs of the
+ *                  same code (timestamps, accruing balances, oracle prices)
+ *
+ * Usage:
+ *   npx tsx scripts/migration-diff.ts            # report
+ *   npx tsx scripts/migration-diff.ts --strict   # show ALL diffs incl. noise
+ *   npx tsx scripts/migration-diff.ts --file lstInfo.json   # focus one file
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const BEFORE_DIR = path.join("scripts", "snapshots", "before");
+const AFTER_DIR = path.join("scripts", "snapshots", "after");
+
+interface Diff {
+  path: string;
+  before: unknown;
+  after: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Noise classification — accruing accumulators, chain time, oracle prices.
+// ---------------------------------------------------------------------------
+const NOISE_SUFFIXES = new Set<string>([
+  // accumulating chain accumulators inside lstInfo
+  "accruedSpreadFees",
+  "accrued_spread_fees",
+  "totalSuiSupply",
+  "total_sui_supply",
+  "total_sui_amount",
+  "sui_pool",
+  "totalStSuiSupply",
+  "totalWeight",
+  "total_weight",
+  "lastRefreshEpoch",
+  "last_refresh_epoch",
+  "value", // total_supply.value — tracks live stSUI supply
+  // chain time
+  "epoch",
+  "lastUpdateEventTimestamp",
+  "last_update_event_timestamp",
+  // derived metric values
+  "rate", // stSuiExchangeRate.rate
+  "supply", // stStuiCirculationSupply.supply, getMultiObjects total_supply
+  "staked", // fetchTotalSuiStaked.staked
+  "totalStakers",
+  "apr",
+  "apy",
+  "totalBalance",
+  "balance",
+  "coinObjectCount",
+  // pyth (live oracle)
+  "price",
+  // event-window noise
+  "timestamp",
+  "txDigest",
+  "eventSeq",
+]);
+
+// Per-file extra noise patterns.
+function extraNoiseForFile(file: string): (path: string) => boolean {
+  if (file.startsWith("events-")) {
+    // Events come and go between runs; everything inside the array is volatile.
+    return () => true;
+  }
+  if (file === "balances.json" || file === "allBalances.json") {
+    // Per-balance numeric drift fully expected.
+    return () => true;
+  }
+  if (
+    file === "latestPrices-SUI.json" ||
+    file === "latestTokenPricePairs-SUI.json"
+  ) {
+    return () => true;
+  }
+  return () => false;
+}
+
+function isNoise(diffPath: string, file: string): boolean {
+  const segs = diffPath.split(".");
+  for (let i = segs.length - 1; i >= 0; i--) {
+    const seg = segs[i].replace(/\[\d+\]$/, "");
+    if (NOISE_SUFFIXES.has(seg)) return true;
+    // walk past array-index segments
+    if (!/^\d+$/.test(seg)) break;
+  }
+  if (extraNoiseForFile(file)(diffPath)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Expected (intentional) deltas, classified separately from signal.
+// ---------------------------------------------------------------------------
+
+interface ExpectedFix {
+  match(file: string, diffPath: string): boolean;
+  reason: string;
+}
+
+const EXPECTED_FIXES: ExpectedFix[] = [
+  {
+    match: (file) => file === "walletCoins.json",
+    reason:
+      "Pre-migration getWalletCoins always returned []; the GraphQL rewrite returns the actual coin list.",
+  },
+];
+
+function expectedReason(diffPath: string, file: string): string | undefined {
+  for (const fix of EXPECTED_FIXES) {
+    if (fix.match(file, diffPath)) return fix.reason;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Generic deep diff.
+// ---------------------------------------------------------------------------
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function diffValues(a: unknown, b: unknown, p: string, diffs: Diff[]) {
+  if (a === b) return;
+  if (typeof a !== typeof b) {
+    diffs.push({ path: p, before: a, after: b });
+    return;
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      diffs.push({ path: `${p}.length`, before: a.length, after: b.length });
+    }
+    const n = Math.min(a.length, b.length);
+    for (let i = 0; i < n; i++) {
+      diffValues(a[i], b[i], `${p}[${i}]`, diffs);
+    }
+    return;
+  }
+  if (isObject(a) && isObject(b)) {
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+    for (const k of keys) {
+      if (!(k in a)) {
+        diffs.push({ path: `${p}.${k}`, before: undefined, after: b[k] });
+        continue;
+      }
+      if (!(k in b)) {
+        diffs.push({ path: `${p}.${k}`, before: a[k], after: undefined });
+        continue;
+      }
+      diffValues(a[k], b[k], `${p}.${k}`, diffs);
+    }
+    return;
+  }
+  if (a !== b) diffs.push({ path: p, before: a, after: b });
+}
+
+function listSnapshots(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .sort();
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+function fmtVal(v: unknown): string {
+  const s = JSON.stringify(v);
+  if (s === undefined) return "<undef>";
+  if (s.length > 120) return s.slice(0, 117) + "...";
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let strict = false;
+  let onlyFile: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--strict") strict = true;
+    else if (args[i] === "--file" && i + 1 < args.length) {
+      onlyFile = args[i + 1];
+      i++;
+    }
+  }
+  return { strict, onlyFile };
+}
+
+function main() {
+  const { strict, onlyFile } = parseArgs();
+
+  const beforeFiles = new Set(listSnapshots(BEFORE_DIR));
+  const afterFiles = new Set(listSnapshots(AFTER_DIR));
+
+  if (beforeFiles.size === 0) {
+    console.error(`No snapshots in ${BEFORE_DIR}. Capture --out before first.`);
+    process.exit(1);
+  }
+  if (afterFiles.size === 0) {
+    console.error(`No snapshots in ${AFTER_DIR}. Capture --out after first.`);
+    process.exit(1);
+  }
+
+  const onlyBefore = [...beforeFiles].filter((f) => !afterFiles.has(f));
+  const onlyAfter = [...afterFiles].filter((f) => !beforeFiles.has(f));
+
+  if (onlyBefore.length || onlyAfter.length) {
+    console.log("File set differences:");
+    for (const f of onlyBefore) console.log(`  -- only in before: ${f}`);
+    for (const f of onlyAfter) console.log(`  ++ only in after:  ${f}`);
+    console.log("");
+  }
+
+  let shared = [...beforeFiles].filter((f) => afterFiles.has(f));
+  if (onlyFile) {
+    shared = shared.filter((f) => f === onlyFile);
+    if (shared.length === 0) {
+      console.error(`No shared snapshot named ${onlyFile}.`);
+      process.exit(1);
+    }
+  }
+
+  let totalDiffs = 0;
+  let totalSignal = 0;
+  let totalExpected = 0;
+  let totalNoise = 0;
+  const filesWithSignal: {
+    file: string;
+    signal: Diff[];
+    expected: Diff[];
+    noise: Diff[];
+  }[] = [];
+  const expectedTally = new Map<string, number>();
+
+  for (const f of shared) {
+    const a = readJson(path.join(BEFORE_DIR, f));
+    const b = readJson(path.join(AFTER_DIR, f));
+    const diffs: Diff[] = [];
+    diffValues(a, b, "$", diffs);
+    totalDiffs += diffs.length;
+    if (diffs.length === 0) continue;
+
+    const signal: Diff[] = [];
+    const expected: Diff[] = [];
+    const noise: Diff[] = [];
+    for (const d of diffs) {
+      const reason = expectedReason(d.path, f);
+      if (reason) {
+        expected.push(d);
+        expectedTally.set(reason, (expectedTally.get(reason) ?? 0) + 1);
+      } else if (isNoise(d.path, f)) {
+        noise.push(d);
+      } else {
+        signal.push(d);
+      }
+    }
+    totalSignal += signal.length;
+    totalExpected += expected.length;
+    totalNoise += noise.length;
+    if (signal.length > 0 || strict) {
+      filesWithSignal.push({ file: f, signal, expected, noise });
+    }
+  }
+
+  console.log(
+    `Compared ${shared.length} snapshot(s). ${totalDiffs} raw diffs ` +
+      `(${totalSignal} signal, ${totalExpected} expected-fix, ${totalNoise} noise).\n`,
+  );
+
+  if (totalExpected > 0) {
+    console.log("Expected (intentional) migration deltas:");
+    for (const [reason, n] of expectedTally.entries()) {
+      console.log(`  x${n}  ${reason}`);
+    }
+    console.log("");
+  }
+
+  if (totalSignal === 0) {
+    console.log(
+      "All shared snapshots are semantically identical (after filtering " +
+        "known time-drift noise and intentional migration deltas).",
+    );
+    return;
+  }
+
+  for (const { file, signal, expected, noise } of filesWithSignal) {
+    const total = signal.length + expected.length + noise.length;
+    console.log(`-- ${file}  (${signal.length} signal / ${total} total)`);
+    const toShow = strict ? [...signal, ...expected, ...noise] : signal;
+    for (const d of toShow.slice(0, 30)) {
+      let tag = "[SIGNAL]";
+      if (expectedReason(d.path, file)) tag = "[expected]";
+      else if (isNoise(d.path, file)) tag = "[noise]";
+      console.log(`   ${tag} ${d.path}`);
+      console.log(`           - ${fmtVal(d.before)}`);
+      console.log(`           + ${fmtVal(d.after)}`);
+    }
+    if (toShow.length > 30) {
+      console.log(`   ... ${toShow.length - 30} more`);
+    }
+    console.log("");
+  }
+
+  if (totalSignal > 0) process.exitCode = 1;
+}
+
+main();

--- a/scripts/migration-snapshot.ts
+++ b/scripts/migration-snapshot.ts
@@ -43,6 +43,7 @@ import {
   getLstInfo,
   getMeta,
   getMultiObjects,
+  multiGetObjectsGraphql,
   stStuiCirculationSupply,
   stSuiExchangeRate,
   // tx builder free functions
@@ -361,7 +362,7 @@ async function main() {
   );
 
   await step(
-    "[reads] getMultiObjects([LST_INFO, META_OBJECT])",
+    "[reads] getMultiObjects([LST_INFO, META_OBJECT])  (legacy JSON-RPC)",
     () =>
       getMultiObjects({
         ids: [LST_INFO_ID, META_OBJECT_ID],
@@ -377,6 +378,17 @@ async function main() {
         return extractMultiObject(wrap?.data ?? wrap);
       });
       writeSnapshot(outDir, "getMultiObjects-2", projected);
+    },
+  );
+
+  await step(
+    "[reads] multiGetObjectsGraphql([LST_INFO, META_OBJECT])  (new GraphQL)",
+    () => multiGetObjectsGraphql([LST_INFO_ID, META_OBJECT_ID]),
+    (objs) => {
+      const projected = (objs as unknown[]).map((r) =>
+        extractMultiObject(asObj(r)),
+      );
+      writeSnapshot(outDir, "multiGetObjectsGraphql-2", projected);
     },
   );
 

--- a/scripts/migration-snapshot.ts
+++ b/scripts/migration-snapshot.ts
@@ -1,0 +1,767 @@
+/**
+ * Migration Snapshot Script (stsui-sdk)
+ *
+ * Captures the parsed/observable output of every public function in the
+ * stSUI SDK, plus a normalized "skeleton" of every transaction builder,
+ * into JSON files under `scripts/snapshots/<--out>/`.
+ *
+ * The script touches ONLY public exports, so the same script runs
+ * unchanged on both the pre-migration (JSON-RPC) tree and the migrated
+ * (GraphQL) tree.
+ *
+ * For Cat 1 reads (`getLstInfo`, `getMeta`, `getMultiObjects`) the public
+ * return shape changes during the migration (nested `{type, fields}`
+ * wrappers go away). To keep the diff focused on real value drift rather
+ * than shape change, those captures use focused projection helpers
+ * (`extractLstInfo`, `extractMeta`, `extractMultiObject`) that handle
+ * BOTH shapes via `??` fallback. Both runs of the snapshot script
+ * produce the same canonical JSON regardless of which SDK build is
+ * running.
+ *
+ * Usage:
+ *   npx tsx scripts/migration-snapshot.ts --out before
+ *   npx tsx scripts/migration-snapshot.ts --out after
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+import { Transaction } from "@mysten/sui/transactions";
+
+import {
+  Events,
+  Utils,
+  LST,
+  Admin,
+  fetchCurrentStSuiEpoch,
+  fetchStSuiAPR,
+  fetchStSuiAPY,
+  fetchTotalStakers,
+  fetchTotalSuiStaked,
+  getConf,
+  getFees,
+  getLstInfo,
+  getMeta,
+  getMultiObjects,
+  stStuiCirculationSupply,
+  stSuiExchangeRate,
+  // tx builder free functions
+  mint,
+  redeem,
+  refresh,
+  create_lst,
+  collect_fee,
+  updateFee,
+  setValidators,
+  // balance / coin
+  getBalances,
+  getAllBalances,
+  getWalletCoins,
+  // pyth
+  getLatestPrices,
+  getLatestTokenPricePairs,
+} from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const TEST_ADDRESS =
+  "0xe136f0b6faf27ee707725f38f2aeefc51c6c31cc508222bee5cbc4f5fcf222c3";
+const SUI_COIN_TYPE = "0x2::sui::SUI";
+
+// Build-time amounts. Values themselves don't matter for tx skeletons.
+const MINT_SUI_AMOUNT = "1000000000"; // 1 SUI
+const REDEEM_STSUI_AMOUNT = "100000000";
+
+// Placeholder admin params — not real caps. Used only so the tx builder
+// runs to completion. The resulting tx is not executed.
+const FAKE_TREASURY_CAP =
+  "0x000000000000000000000000000000000000000000000000000000000000aaaa";
+const FAKE_ADMIN_CAP =
+  "0x000000000000000000000000000000000000000000000000000000000000bbbb";
+const FAKE_COLLECTION_FEE_CAP =
+  "0x000000000000000000000000000000000000000000000000000000000000cccc";
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let out = "before";
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--out" && i + 1 < args.length) {
+      out = args[i + 1];
+      i++;
+    }
+  }
+  return { out };
+}
+
+// ---------------------------------------------------------------------------
+// JSON serialization that preserves BigInt and Map.
+// ---------------------------------------------------------------------------
+function jsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Map) {
+    const obj: Record<string, unknown> = {};
+    for (const [k, v] of value) obj[String(k)] = v;
+    return obj;
+  }
+  return value;
+}
+
+function writeSnapshot(dir: string, name: string, data: unknown) {
+  const filePath = path.join(dir, `${name}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(data, jsonReplacer, 2) + "\n");
+  console.log(`  wrote ${filePath}`);
+}
+
+// ---------------------------------------------------------------------------
+// Bi-shape projections for Cat 1 reads.
+// Old (JSON-RPC) shape: lstInfo.content.fields.X.fields.Y
+// New (GraphQL flat) shape: lstInfo.fields.X.Y
+// Each projection tries the new path first, falls back to the old path.
+// ---------------------------------------------------------------------------
+
+interface AnyObj {
+  [k: string]: unknown;
+}
+function asObj(v: unknown): AnyObj | undefined {
+  return v && typeof v === "object" && !Array.isArray(v)
+    ? (v as AnyObj)
+    : undefined;
+}
+
+/**
+ * Recursively strip the JSON-RPC `{ type: string, fields: object }`
+ * wrapping that the legacy `getObject({showContent: true})` API applies
+ * to every nested Move struct. The post-migration GraphQL response is
+ * flat (no wrapping), so applying this on the BEFORE shape produces the
+ * same canonical flat shape.
+ *
+ * Also unwraps the JSON-RPC `id: { id: address }` UID encoding to a
+ * plain `id: address` so the diff doesn't trip on UID fields. (GraphQL
+ * also nests UIDs the same way in some responses; if one side stays
+ * nested we'd have a diff. Stripping on both inputs keeps them aligned.)
+ */
+function stripJsonRpcWrap(v: unknown): unknown {
+  if (Array.isArray(v)) return v.map(stripJsonRpcWrap);
+  if (v && typeof v === "object") {
+    const obj = v as AnyObj;
+    const keys = Object.keys(obj);
+    // {type, fields} wrapper around any Move struct -> just unwrap.
+    if (
+      keys.length === 2 &&
+      keys.includes("type") &&
+      keys.includes("fields") &&
+      typeof obj.type === "string" &&
+      obj.fields &&
+      typeof obj.fields === "object" &&
+      !Array.isArray(obj.fields)
+    ) {
+      return stripJsonRpcWrap(obj.fields);
+    }
+    const out: AnyObj = {};
+    for (const [k, val] of Object.entries(obj)) {
+      // UID field flattening: a field named `id` whose value is `{ id: string }`
+      // collapses to just the string. Keeps before/after aligned for any
+      // struct that contains a `UID id` field.
+      if (
+        k === "id" &&
+        val &&
+        typeof val === "object" &&
+        !Array.isArray(val) &&
+        Object.keys(val as AnyObj).length === 1 &&
+        typeof (val as AnyObj).id === "string"
+      ) {
+        out[k] = (val as AnyObj).id;
+      } else {
+        out[k] = stripJsonRpcWrap(val);
+      }
+    }
+    return out;
+  }
+  return v;
+}
+
+function extractLstInfo(lstInfo: unknown) {
+  if (!lstInfo) return null;
+  const obj = asObj(lstInfo);
+  if (!obj) return null;
+  // Locate "fields" — flat: obj.fields. nested: obj.content.fields.
+  const fields =
+    asObj(obj.fields) ?? asObj(asObj(obj.content)?.fields) ?? undefined;
+  if (!fields) return null;
+
+  // storage struct: flat is direct. nested wraps in { fields: ... }.
+  const storage = asObj(asObj(fields.storage)?.fields) ?? asObj(fields.storage);
+  // lst_treasury_cap.total_supply.value
+  const treasury =
+    asObj(asObj(fields.lst_treasury_cap)?.fields) ??
+    asObj(fields.lst_treasury_cap);
+  const totalSupply =
+    asObj(asObj(treasury?.total_supply)?.fields) ??
+    asObj(treasury?.total_supply);
+  // fee_config.element
+  const feeConfig =
+    asObj(asObj(asObj(fields.fee_config)?.fields)?.element) ??
+    asObj(asObj(fields.fee_config)?.element);
+  const feeConfigFields =
+    asObj((feeConfig as AnyObj | undefined)?.fields) ?? feeConfig;
+
+  return {
+    objectId: obj.objectId,
+    accruedSpreadFees: fields.accrued_spread_fees,
+    fees: fields.fees,
+    totalSuiSupply: storage?.total_sui_supply,
+    totalStSuiSupply: totalSupply?.value,
+    lastRefreshEpoch: storage?.last_refresh_epoch,
+    totalWeight: storage?.total_weight,
+    feeConfig: stripJsonRpcWrap(feeConfigFields),
+  };
+}
+
+function extractMeta(meta: unknown) {
+  if (!meta) return null;
+  const obj = asObj(meta);
+  if (!obj) return null;
+  const fields =
+    asObj(obj.fields) ?? asObj(asObj(obj.content)?.fields) ?? undefined;
+  if (!fields) return null;
+
+  const stakers = asObj(asObj(fields.stakers)?.fields) ?? asObj(fields.stakers);
+
+  return {
+    objectId: obj.objectId,
+    lastUpdateEventTimestamp: fields.last_update_event_timestamp,
+    stakersSize: stakers?.size,
+  };
+}
+
+function extractMultiObject(o: unknown) {
+  if (!o) return null;
+  const obj = asObj(o);
+  if (!obj) return null;
+  const rawFields =
+    asObj(obj.fields) ?? asObj(asObj(obj.content)?.fields) ?? null;
+  return {
+    objectId: obj.objectId,
+    // type from either old (content.type) or new (type)
+    type: obj.type ?? asObj(obj.content)?.type,
+    // strip JSON-RPC nested wrapping so before/after match
+    fields: rawFields ? stripJsonRpcWrap(rawFields) : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event projection (shape stable across migration; just trim noise).
+// ---------------------------------------------------------------------------
+function projectEvent(e: unknown) {
+  const obj = asObj(e);
+  if (!obj) return null;
+  return {
+    sender: obj.sender,
+    timestamp: obj.timestamp,
+    type: obj.type,
+    txDigest: obj.txDigest,
+    eventSeq: obj.eventSeq,
+    event: obj.event,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tier-1 transaction normalization (mirror of alphalend-sdk-js).
+// ---------------------------------------------------------------------------
+const VOLATILE_KEYS = new Set(["version", "digest", "initialSharedVersion"]);
+
+function deepStripVolatile(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(deepStripVolatile);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (VOLATILE_KEYS.has(k)) continue;
+      out[k] = deepStripVolatile(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+function normalizeTx(tx: Transaction): unknown {
+  const data = tx.getData() as Record<string, unknown>;
+  const trimmed: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(data)) {
+    if (k === "gasData" || k === "expiration") continue;
+    trimmed[k] = v;
+  }
+  return deepStripVolatile(trimmed);
+}
+
+// ---------------------------------------------------------------------------
+// step(): time + log + capture errors AND time out individual calls so a
+// single hang doesn't stall the entire snapshot run. Default per-step
+// timeout is 60s; override via the third arg for known-long calls.
+// ---------------------------------------------------------------------------
+const DEFAULT_STEP_TIMEOUT_MS = 60_000;
+
+async function step<T>(
+  label: string,
+  fn: () => Promise<T>,
+  onResult: (value: T) => void,
+  timeoutMs: number = DEFAULT_STEP_TIMEOUT_MS,
+): Promise<void> {
+  console.log(label);
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`step timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+  try {
+    const t0 = Date.now();
+    const value = (await Promise.race([fn(), timeout])) as T;
+    onResult(value);
+    console.log(`  ok (${Date.now() - t0}ms)`);
+  } catch (err) {
+    console.warn(`  WARN: ${label} failed:`, err);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  const { out } = parseArgs();
+  const outDir = path.join("scripts", "snapshots", out);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  console.log(`Snapshot directory: ${outDir}`);
+  console.log(`Test address: ${TEST_ADDRESS}\n`);
+
+  const conf = getConf();
+  const LST_INFO_ID = conf.LST_INFO;
+  const STSUI_COIN_TYPE = conf.STSUI_COIN_TYPE;
+  const META_OBJECT_ID = conf.META_OBJECT;
+
+  // -------------------------------------------------------------------
+  // READS: object reads (Cat 1)
+  // -------------------------------------------------------------------
+
+  await step(
+    "[reads] getLstInfo(LST_INFO, ignoreCache=true)",
+    () => getLstInfo(LST_INFO_ID, true),
+    (info) => writeSnapshot(outDir, "lstInfo", extractLstInfo(info)),
+  );
+
+  await step(
+    "[reads] getMeta()",
+    () => getMeta(),
+    (meta) => writeSnapshot(outDir, "meta", extractMeta(meta)),
+  );
+
+  await step(
+    "[reads] getMultiObjects([LST_INFO, META_OBJECT])",
+    () =>
+      getMultiObjects({
+        ids: [LST_INFO_ID, META_OBJECT_ID],
+        options: { showContent: true },
+      }),
+    (objs) => {
+      // The JSON-RPC version returns SuiObjectResponse[]; we project to a
+      // canonical flat shape that handles both before and after.
+      const projected = (objs as unknown[]).map((r) => {
+        const wrap = asObj(r);
+        // SuiObjectResponse wraps in `{ data: ... }`; our migrated flat
+        // version may return either shape. Try both.
+        return extractMultiObject(wrap?.data ?? wrap);
+      });
+      writeSnapshot(outDir, "getMultiObjects-2", projected);
+    },
+  );
+
+  // -------------------------------------------------------------------
+  // READS: derived metrics (utils.ts)
+  // -------------------------------------------------------------------
+
+  await step(
+    "[reads] stSuiExchangeRate()",
+    () => stSuiExchangeRate(LST_INFO_ID, true),
+    (rate) => writeSnapshot(outDir, "stSuiExchangeRate", { rate }),
+  );
+
+  await step(
+    "[reads] stStuiCirculationSupply()",
+    () => stStuiCirculationSupply(LST_INFO_ID, true),
+    (supply) => writeSnapshot(outDir, "stStuiCirculationSupply", { supply }),
+  );
+
+  await step(
+    "[reads] fetchTotalSuiStaked()",
+    () => fetchTotalSuiStaked(LST_INFO_ID, true),
+    (staked) => writeSnapshot(outDir, "fetchTotalSuiStaked", { staked }),
+  );
+
+  await step(
+    "[reads] fetchCurrentStSuiEpoch()",
+    () => fetchCurrentStSuiEpoch(),
+    (epoch) => writeSnapshot(outDir, "fetchCurrentStSuiEpoch", { epoch }),
+  );
+
+  await step(
+    "[reads] fetchTotalStakers()",
+    () => fetchTotalStakers(),
+    (n) => writeSnapshot(outDir, "fetchTotalStakers", { totalStakers: n }),
+  );
+
+  await step(
+    "[reads] getFees(LST_INFO, ignoreCache=true)",
+    () => getFees(LST_INFO_ID, true),
+    (fees) =>
+      writeSnapshot(outDir, "getFees", fees ? stripJsonRpcWrap(fees) : null),
+  );
+
+  for (const days of [1, 7, 30, 365]) {
+    await step(
+      `[reads] fetchStSuiAPR(${days})`,
+      () => fetchStSuiAPR(days),
+      (apr) => writeSnapshot(outDir, `fetchStSuiAPR-${days}`, { apr }),
+    );
+    await step(
+      `[reads] fetchStSuiAPY(${days})`,
+      () => fetchStSuiAPY(days),
+      (apy) => writeSnapshot(outDir, `fetchStSuiAPY-${days}`, { apy }),
+    );
+  }
+
+  // -------------------------------------------------------------------
+  // READS: events (last 7 days)
+  // -------------------------------------------------------------------
+
+  const now = Date.now();
+  const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
+
+  // Events queries paginate over potentially many pages of global event
+  // history filtered server-side; bump the timeout to 120s each.
+  const EVENTS_TIMEOUT_MS = 120_000;
+
+  await step(
+    "[reads] Events.getMintEvents(7d)",
+    () =>
+      Events.getMintEvents({
+        startTime: sevenDaysAgo,
+        endTime: now,
+        typeName: STSUI_COIN_TYPE,
+      }),
+    (events) =>
+      writeSnapshot(outDir, "events-mint-7d", events.map(projectEvent)),
+    EVENTS_TIMEOUT_MS,
+  );
+
+  // Note: Events.getRedeemEvents is intentionally skipped — on the
+  // pre-migration JSON-RPC API the descending pagination scans far more
+  // pages than for mint/epoch/flash and times out reliably. The shape of
+  // a RedeemEvent is structurally identical to MintEvent, so coverage of
+  // mint events validates the parsing path.
+
+  await step(
+    "[reads] Events.getEpochChangeEvents(7d)",
+    () =>
+      Events.getEpochChangeEvents({
+        startTime: sevenDaysAgo,
+        endTime: now,
+        typeName: STSUI_COIN_TYPE,
+      }),
+    (events) =>
+      writeSnapshot(outDir, "events-epoch-7d", events.map(projectEvent)),
+    EVENTS_TIMEOUT_MS,
+  );
+
+  await step(
+    "[reads] Events.getFlashStakeEvents(7d)",
+    () =>
+      Events.getFlashStakeEvents({
+        startTime: sevenDaysAgo,
+        endTime: now,
+        typeName: STSUI_COIN_TYPE,
+      }),
+    (events) =>
+      writeSnapshot(outDir, "events-flash-7d", events.map(projectEvent)),
+    EVENTS_TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------
+  // READS: balance / coin
+  // -------------------------------------------------------------------
+
+  await step(
+    "[reads] getBalances(TEST_ADDR, ['SUI','STSUI'])",
+    () => getBalances(TEST_ADDRESS, ["SUI", "STSUI"]),
+    (balances) => writeSnapshot(outDir, "balances", balances),
+  );
+
+  await step(
+    "[reads] getAllBalances(TEST_ADDR)",
+    () => getAllBalances(TEST_ADDRESS),
+    (balances) => writeSnapshot(outDir, "allBalances", balances),
+  );
+
+  await step(
+    "[reads] getWalletCoins(TEST_ADDR)",
+    () => getWalletCoins(TEST_ADDRESS),
+    (coins) => writeSnapshot(outDir, "walletCoins", coins),
+  );
+
+  // -------------------------------------------------------------------
+  // READS: pyth (no Sui involvement; sanity check)
+  // -------------------------------------------------------------------
+
+  await step(
+    "[reads] getLatestPrices(['SUI/USD'])",
+    () => getLatestPrices(["SUI/USD"], true),
+    (prices) => writeSnapshot(outDir, "latestPrices-SUI", prices),
+  );
+
+  await step(
+    "[reads] getLatestTokenPricePairs(['SUI/USD'])",
+    () => getLatestTokenPricePairs(["SUI/USD"], true),
+    (pairs) => writeSnapshot(outDir, "latestTokenPricePairs-SUI", pairs),
+  );
+
+  // -------------------------------------------------------------------
+  // Utils class (delegates to free functions; snapshot one path through
+  // it to confirm the class wrapping doesn't drift).
+  // -------------------------------------------------------------------
+
+  const utils = new Utils({
+    lstInfo: LST_INFO_ID,
+    lstCointype: STSUI_COIN_TYPE,
+  });
+
+  await step(
+    "[reads] Utils.lstExchangeRate(true)",
+    () => utils.lstExchangeRate(true),
+    (rate) => writeSnapshot(outDir, "utils-lstExchangeRate", { rate }),
+  );
+
+  await step(
+    "[reads] Utils.lstCirculationSupply(true)",
+    () => utils.lstCirculationSupply(true),
+    (s) => writeSnapshot(outDir, "utils-lstCirculationSupply", { supply: s }),
+  );
+
+  await step(
+    "[reads] Utils.fetchTotalSuiStaked(true)",
+    () => utils.fetchTotalSuiStaked(true),
+    (s) => writeSnapshot(outDir, "utils-fetchTotalSuiStaked", { staked: s }),
+  );
+
+  // -------------------------------------------------------------------
+  // TRANSACTIONS: Tier-1 normalized skeletons
+  // -------------------------------------------------------------------
+
+  await step(
+    "[tx] mint(LST_INFO, STSUI_COIN_TYPE, 1 SUI, TEST_ADDRESS)",
+    async () =>
+      normalizeTx(
+        await mint(LST_INFO_ID, STSUI_COIN_TYPE, MINT_SUI_AMOUNT, TEST_ADDRESS),
+      ),
+    (data) => writeSnapshot(outDir, "tx-mint", data),
+  );
+
+  await step(
+    "[tx] redeem(LST_INFO, STSUI_COIN_TYPE, 0.1 stSUI, TEST_ADDRESS)",
+    async () =>
+      normalizeTx(
+        await redeem(
+          LST_INFO_ID,
+          STSUI_COIN_TYPE,
+          REDEEM_STSUI_AMOUNT,
+          TEST_ADDRESS,
+        ),
+      ),
+    (data) => writeSnapshot(outDir, "tx-redeem", data),
+  );
+
+  await step(
+    "[tx] refresh(LST_INFO, STSUI_COIN_TYPE)",
+    async () => {
+      const tx = await refresh(LST_INFO_ID, STSUI_COIN_TYPE);
+      if (!tx) throw new Error("refresh returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-refresh", data),
+  );
+
+  await step(
+    "[tx] create_lst(fakeTreasuryCap, STSUI_COIN_TYPE, 0,1,600,10000, addr)",
+    async () =>
+      normalizeTx(
+        await create_lst(
+          FAKE_TREASURY_CAP,
+          STSUI_COIN_TYPE,
+          0,
+          1,
+          600,
+          10000,
+          TEST_ADDRESS,
+        ),
+      ),
+    (data) => writeSnapshot(outDir, "tx-create_lst", data),
+  );
+
+  await step(
+    "[tx] collect_fee(LST_INFO, STSUI_COIN_TYPE, fakeCollectionFeeCap, addr)",
+    async () => {
+      const tx = await collect_fee(
+        LST_INFO_ID,
+        STSUI_COIN_TYPE,
+        FAKE_COLLECTION_FEE_CAP,
+        TEST_ADDRESS,
+      );
+      if (!tx) throw new Error("collect_fee returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-collect_fee", data),
+  );
+
+  await step(
+    "[tx] updateFee(LST_INFO, fakeAdminCap, STSUI_COIN_TYPE, 0,1,600,10000)",
+    async () => {
+      const tx = await updateFee(
+        LST_INFO_ID,
+        FAKE_ADMIN_CAP,
+        STSUI_COIN_TYPE,
+        0,
+        1,
+        600,
+        10000,
+      );
+      if (!tx) throw new Error("updateFee returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-updateFee", data),
+  );
+
+  await step(
+    "[tx] setValidators(LST_INFO, fakeAdminCap, STSUI_COIN_TYPE, [addr], [100])",
+    async () => {
+      const tx = await setValidators(
+        LST_INFO_ID,
+        FAKE_ADMIN_CAP,
+        STSUI_COIN_TYPE,
+        [TEST_ADDRESS],
+        [100],
+      );
+      if (!tx) throw new Error("setValidators returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-setValidators", data),
+  );
+
+  // -------------------------------------------------------------------
+  // Class-based wrappers (LST.mint, Admin.createLst etc.) — verify they
+  // produce the same skeleton as the free function variants.
+  // -------------------------------------------------------------------
+
+  const lst = new LST({
+    lstInfo: LST_INFO_ID,
+    lstCointype: STSUI_COIN_TYPE,
+  });
+  const admin = new Admin({
+    lstInfo: LST_INFO_ID,
+    lstCointype: STSUI_COIN_TYPE,
+    treasuryCap: FAKE_TREASURY_CAP,
+    adminCap: FAKE_ADMIN_CAP,
+    collectionFeeCap: FAKE_COLLECTION_FEE_CAP,
+  });
+
+  await step(
+    "[tx] LST.mint(1 SUI, TEST_ADDRESS)",
+    async () => {
+      const tx = await lst.mint(MINT_SUI_AMOUNT, TEST_ADDRESS);
+      if (!tx) throw new Error("LST.mint returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-LST.mint", data),
+  );
+
+  await step(
+    "[tx] LST.redeem(0.1 stSUI, TEST_ADDRESS)",
+    async () => {
+      const tx = await lst.redeem(REDEEM_STSUI_AMOUNT, TEST_ADDRESS);
+      if (!tx) throw new Error("LST.redeem returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-LST.redeem", data),
+  );
+
+  await step(
+    "[tx] LST.refresh()",
+    async () => {
+      const tx = await lst.refresh();
+      if (!tx) throw new Error("LST.refresh returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-LST.refresh", data),
+  );
+
+  await step(
+    "[tx] Admin.createLst(0,1,600,10000, addr)",
+    async () => {
+      const tx = await admin.createLst(0, 1, 600, 10000, TEST_ADDRESS);
+      if (!tx) throw new Error("Admin.createLst returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-Admin.createLst", data),
+  );
+
+  await step(
+    "[tx] Admin.collectFee(addr)",
+    async () => {
+      const tx = await admin.collectFee(TEST_ADDRESS);
+      if (!tx) throw new Error("Admin.collectFee returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-Admin.collectFee", data),
+  );
+
+  await step(
+    "[tx] Admin.updateFee(0,1,600,10000)",
+    async () => {
+      const tx = await admin.updateFee(0, 1, 600, 10000);
+      if (!tx) throw new Error("Admin.updateFee returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-Admin.updateFee", data),
+  );
+
+  await step(
+    "[tx] Admin.setValidators([addr], [100])",
+    async () => {
+      const tx = await admin.setValidators([TEST_ADDRESS], [100]);
+      if (!tx) throw new Error("Admin.setValidators returned undefined");
+      return normalizeTx(tx);
+    },
+    (data) => writeSnapshot(outDir, "tx-Admin.setValidators", data),
+  );
+
+  // Note: updateTotalStakers is intentionally skipped — it paginates
+  // every Mint event since the meta object was last updated, which
+  // reliably runs to many thousands of events and times out. The other
+  // mint-event coverage above already exercises the same parsing path.
+
+  console.log("\nSnapshot complete.");
+}
+
+main()
+  .then(() => {
+    // Force exit so any rogue async work (e.g. paginated event fetches we
+    // already abandoned via Promise.race timeout) doesn't keep the process
+    // alive past completion.
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/balance.ts
+++ b/src/balance.ts
@@ -1,15 +1,11 @@
 import { coins } from "./coin/constants.js";
-import { getSuiClient } from "./common/client.js";
+import { getAllBalancesForOwner } from "./common/blockchain.js";
 
 export async function getBalances(
   owner: string,
   tokenNames: string[],
 ): Promise<{ tokenName: string; balance: string }[]> {
-  const suiClient = getSuiClient();
-
-  const allBalances = await suiClient.getAllBalances({
-    owner: owner,
-  });
+  const allBalances = await getAllBalancesForOwner(owner);
   const selectedCoins = Object.values(coins).filter((coin) =>
     tokenNames.includes(coin.name),
   );
@@ -32,9 +28,7 @@ export async function getBalances(
 export async function getAllBalances(
   owner: string,
 ): Promise<{ tokenName: string; balance: string }[]> {
-  const suiClient = getSuiClient();
-
-  const allBalances = await suiClient.getAllBalances({ owner });
+  const allBalances = await getAllBalancesForOwner(owner);
 
   const balances = allBalances.map((balance) => {
     const coin = Object.values(coins).find(

--- a/src/coin/index.ts
+++ b/src/coin/index.ts
@@ -1,4 +1,4 @@
-import type { CoinName, CoinType, Icon, Coin } from "./types.js";
+import type { Coin } from "./types.js";
 import { coins } from "./constants.js";
 import { getAllCoinsForOwner } from "../common/blockchain.js";
 
@@ -29,16 +29,6 @@ export async function getWalletCoins(owner: string): Promise<Coin[]> {
       );
       if (known) {
         out.push(known);
-      } else {
-        // Surface unknown coins with best-effort metadata so callers
-        // get the same coverage GraphQL gives them.
-        const symbol = c.coinType.split("::").pop() ?? c.coinType;
-        out.push({
-          name: symbol as CoinName,
-          type: c.coinType as CoinType,
-          icon: "" as Icon,
-          expo: 0,
-        });
       }
     }
     if (page.hasNextPage && page.nextCursor) {

--- a/src/coin/index.ts
+++ b/src/coin/index.ts
@@ -1,38 +1,51 @@
-import { Coin } from "./types.js";
-import { PaginatedCoins } from "@mysten/sui/client";
-import { getSuiClient } from "../common/client.js";
+import type { CoinName, CoinType, Icon, Coin } from "./types.js";
+import { coins } from "./constants.js";
+import { getAllCoinsForOwner } from "../common/blockchain.js";
 
 export * from "./types.js";
 export * from "./constants.js";
 
-const suiClient = getSuiClient();
-
+/**
+ * List every Coin owned by `owner` that has a known entry in this SDK's
+ * coin constants table.
+ *
+ * Note: pre-migration this function had a bug — it accumulated coin
+ * type strings into a local `coinTypes[]` variable but never populated
+ * the returned `coins[]` array, so callers always got `[]`. The
+ * GraphQL migration fixed that as a drive-by.
+ */
 export async function getWalletCoins(owner: string): Promise<Coin[]> {
-  const coins: Coin[] = [];
-  let currentCursor: string | null | undefined = null;
-  const coinTypes: string[] = [];
-
-  while (true) {
-    const paginatedCoins: PaginatedCoins = await suiClient.getAllCoins({
-      owner: owner,
-      cursor: currentCursor,
-    });
-
-    // Traverse the current page data and push to coins array
-    paginatedCoins.data.forEach((coin) => {
-      console.log(`Coin Name: ${coin.coinType}, Coin Value: ${coin.balance}`);
-      coinTypes.push(coin.coinType);
-    });
-
-    // Check if there's a next page
-    if (paginatedCoins.hasNextPage && paginatedCoins.nextCursor) {
-      currentCursor = paginatedCoins.nextCursor;
+  const out: Coin[] = [];
+  const seen = new Set<string>();
+  let cursor: string | null = null;
+  let hasMore = true;
+  while (hasMore) {
+    const page = await getAllCoinsForOwner(owner, cursor);
+    for (const c of page.data) {
+      if (seen.has(c.coinType)) continue;
+      seen.add(c.coinType);
+      const known = (Object.values(coins) as Coin[]).find(
+        (k) => k.type.toLowerCase() === c.coinType.toLowerCase(),
+      );
+      if (known) {
+        out.push(known);
+      } else {
+        // Surface unknown coins with best-effort metadata so callers
+        // get the same coverage GraphQL gives them.
+        const symbol = c.coinType.split("::").pop() ?? c.coinType;
+        out.push({
+          name: symbol as CoinName,
+          type: c.coinType as CoinType,
+          icon: "" as Icon,
+          expo: 0,
+        });
+      }
+    }
+    if (page.hasNextPage && page.nextCursor) {
+      cursor = page.nextCursor;
     } else {
-      // No more pages available
-      console.log("No more coins available.");
-      break;
+      hasMore = false;
     }
   }
-
-  return coins;
+  return out;
 }

--- a/src/common/blockchain.ts
+++ b/src/common/blockchain.ts
@@ -415,20 +415,23 @@ export async function queryMoveEvents(
   const client = getGraphQLClient();
 
   const res = await client.query<{
-    events: GqlConnection<{
-      sender: { address: string } | null;
-      timestamp: string | null;
-      sequenceNumber: number | string;
-      transaction: { digest: string | null } | null;
-      contents: { type: { repr: string }; json: unknown };
-    }>;
+    events: {
+      pageInfo: { hasPreviousPage: boolean; startCursor: string | null };
+      nodes: Array<{
+        sender: { address: string } | null;
+        timestamp: string | null;
+        sequenceNumber: number | string;
+        transaction: { digest: string | null } | null;
+        contents: { type: { repr: string }; json: unknown };
+      }>;
+    };
   }>({
     query: /* GraphQL */ `
-      query queryMoveEvents($type: String!, $after: String) {
-        events(filter: { type: $type }, first: 50, after: $after) {
+      query queryMoveEvents($type: String!, $before: String) {
+        events(filter: { type: $type }, last: 50, before: $before) {
           pageInfo {
-            hasNextPage
-            endCursor
+            hasPreviousPage
+            startCursor
           }
           nodes {
             sender {
@@ -449,7 +452,7 @@ export async function queryMoveEvents(
         }
       }
     `,
-    variables: { type: eventType, after: cursor },
+    variables: { type: eventType, before: cursor },
   });
   if (res.errors?.length) {
     throw new Error(
@@ -458,29 +461,34 @@ export async function queryMoveEvents(
   }
 
   const conn = res.data?.events;
-  const data: SuiEvent[] = (conn?.nodes ?? []).map((node) => {
-    const ts = node.timestamp ? Date.parse(node.timestamp) : NaN;
-    const evt = {
-      id: {
-        txDigest: node.transaction?.digest ?? "",
-        eventSeq: String(node.sequenceNumber),
-      },
-      // packageId/transactionModule aren't used by stsui-sdk consumers,
-      // but we fill them best-effort from the type string for shape-parity.
-      packageId: node.contents.type.repr.split("::")[0] ?? "",
-      transactionModule: node.contents.type.repr.split("::")[1] ?? "",
-      sender: node.sender?.address ?? "",
-      type: node.contents.type.repr,
-      parsedJson: node.contents.json,
-      bcs: "",
-      bcsEncoding: "base64",
-      timestampMs: Number.isFinite(ts) ? String(ts) : null,
-    } as SuiEvent;
-    return evt;
-  });
+  // Relay backward pagination (`last/before`) typically yields nodes in
+  // forward order within each page, so reverse to keep legacy
+  // JSON-RPC-compatible descending order (newest first).
+  const data: SuiEvent[] = (conn?.nodes ?? [])
+    .map((node) => {
+      const ts = node.timestamp ? Date.parse(node.timestamp) : NaN;
+      const evt = {
+        id: {
+          txDigest: node.transaction?.digest ?? "",
+          eventSeq: String(node.sequenceNumber),
+        },
+        // packageId/transactionModule aren't used by stsui-sdk consumers,
+        // but we fill them best-effort from the type string for shape-parity.
+        packageId: node.contents.type.repr.split("::")[0] ?? "",
+        transactionModule: node.contents.type.repr.split("::")[1] ?? "",
+        sender: node.sender?.address ?? "",
+        type: node.contents.type.repr,
+        parsedJson: node.contents.json,
+        bcs: "",
+        bcsEncoding: "base64",
+        timestampMs: Number.isFinite(ts) ? String(ts) : null,
+      } as SuiEvent;
+      return evt;
+    })
+    .reverse();
   return {
     data,
-    hasNextPage: conn?.pageInfo?.hasNextPage ?? false,
-    nextCursor: conn?.pageInfo?.endCursor ?? null,
+    hasNextPage: conn?.pageInfo?.hasPreviousPage ?? false,
+    nextCursor: conn?.pageInfo?.startCursor ?? null,
   };
 }

--- a/src/common/blockchain.ts
+++ b/src/common/blockchain.ts
@@ -95,7 +95,7 @@ export async function getObjectFlat<T = Record<string, unknown>>(
  * Fetch many objects' flat fields by id. Preserves the order of input ids;
  * objects that don't exist or aren't Move objects appear as `null`.
  */
-export async function multiGetObjectsFlat(
+export async function multiGetObjectsGraphql(
   ids: string[],
 ): Promise<(FlatObject | null)[]> {
   if (ids.length === 0) return [];
@@ -111,7 +111,7 @@ export async function multiGetObjectsFlat(
     } | null>;
   }>({
     query: /* GraphQL */ `
-      query multiGetObjectsFlat($keys: [ObjectKey!]!) {
+      query multiGetObjectsGraphql($keys: [ObjectKey!]!) {
         multiGetObjects(keys: $keys) {
           address
           version

--- a/src/common/blockchain.ts
+++ b/src/common/blockchain.ts
@@ -1,0 +1,486 @@
+/**
+ * GraphQL read primitives for stsui-sdk.
+ *
+ * Free functions that wrap SuiGraphQLClient queries and return shapes
+ * compatible with the legacy JSON-RPC equivalents. Internal SDK code in
+ * `utils.ts`, `events.ts`, `balance.ts`, `coin/index.ts`, and
+ * `stSui/redeem.ts` calls into these helpers instead of `SuiClient`.
+ */
+
+import type { CoinStruct, PaginatedCoins, SuiEvent } from "@mysten/sui/client";
+import { getGraphQLClient } from "./graphql.js";
+
+// ---------------------------------------------------------------------------
+// Shared response shapes (only the fields we read from each query). The
+// SuiGraphQLClient query method is generic so each helper supplies its
+// own typed Result.
+// ---------------------------------------------------------------------------
+
+type CoinBalance = {
+  coinType: string;
+  coinObjectCount: number;
+  totalBalance: string;
+  lockedBalance: Record<string, string>;
+};
+
+interface GqlConnection<T> {
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  nodes: T[];
+}
+
+// ---------------------------------------------------------------------------
+// Cat 1: Object reads — flat shape (drop JSON-RPC `{type, fields}` wrap).
+// ---------------------------------------------------------------------------
+
+/** Flat object shape — GraphQL-native, no nested `{type, fields}` wrap. */
+export interface FlatObject<T = Record<string, unknown>> {
+  objectId: string;
+  version: string;
+  digest: string;
+  type: string;
+  fields: T;
+}
+
+/**
+ * Fetch a single object's flat fields by id.
+ *
+ * Returns `undefined` if the object doesn't exist or isn't a Move object.
+ */
+export async function getObjectFlat<T = Record<string, unknown>>(
+  id: string,
+): Promise<FlatObject<T> | undefined> {
+  const client = getGraphQLClient();
+  const res = await client.query<{
+    object: {
+      address: string;
+      version: number | string;
+      digest: string;
+      asMoveObject: {
+        contents: { type: { repr: string }; json: unknown };
+      } | null;
+    } | null;
+  }>({
+    query: /* GraphQL */ `
+      query getObjectFlat($id: SuiAddress!) {
+        object(address: $id) {
+          address
+          version
+          digest
+          asMoveObject {
+            contents {
+              type {
+                repr
+              }
+              json
+            }
+          }
+        }
+      }
+    `,
+    variables: { id },
+  });
+
+  const obj = res.data?.object;
+  if (!obj || !obj.asMoveObject) return undefined;
+  return {
+    objectId: obj.address,
+    version: String(obj.version),
+    digest: obj.digest,
+    type: obj.asMoveObject.contents.type.repr,
+    fields: obj.asMoveObject.contents.json as T,
+  };
+}
+
+/**
+ * Fetch many objects' flat fields by id. Preserves the order of input ids;
+ * objects that don't exist or aren't Move objects appear as `null`.
+ */
+export async function multiGetObjectsFlat(
+  ids: string[],
+): Promise<(FlatObject | null)[]> {
+  if (ids.length === 0) return [];
+  const client = getGraphQLClient();
+  const res = await client.query<{
+    multiGetObjects: Array<{
+      address: string;
+      version: number | string;
+      digest: string;
+      asMoveObject: {
+        contents: { type: { repr: string }; json: unknown };
+      } | null;
+    } | null>;
+  }>({
+    query: /* GraphQL */ `
+      query multiGetObjectsFlat($keys: [ObjectKey!]!) {
+        multiGetObjects(keys: $keys) {
+          address
+          version
+          digest
+          asMoveObject {
+            contents {
+              type {
+                repr
+              }
+              json
+            }
+          }
+        }
+      }
+    `,
+    variables: { keys: ids.map((id) => ({ address: id })) },
+  });
+
+  // multiGetObjects preserves input order with nulls for missing.
+  return (res.data?.multiGetObjects ?? []).map((node) => {
+    if (!node || !node.asMoveObject) return null;
+    return {
+      objectId: node.address,
+      version: String(node.version),
+      digest: node.digest,
+      type: node.asMoveObject.contents.type.repr,
+      fields: node.asMoveObject.contents.json as Record<string, unknown>,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cat 3: Balances — direct field rename.
+// ---------------------------------------------------------------------------
+
+/**
+ * Get all coin balances for an address (one row per coin type).
+ */
+export async function getAllBalancesForOwner(
+  owner: string,
+): Promise<CoinBalance[]> {
+  const client = getGraphQLClient();
+  const out: CoinBalance[] = [];
+  let cursor: string | null = null;
+  let hasMore = true;
+  while (hasMore) {
+    const variables: { owner: string; cursor: string | null } = {
+      owner,
+      cursor,
+    };
+    const res = await client.query<{
+      address: {
+        balances: GqlConnection<{
+          coinType: { repr: string };
+          coinObjectCount: number;
+          totalBalance: string | null;
+        }>;
+      } | null;
+    }>({
+      query: /* GraphQL */ `
+        query getAllBalances($owner: SuiAddress!, $cursor: String) {
+          address(address: $owner) {
+            balances(after: $cursor) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                coinType {
+                  repr
+                }
+                coinObjectCount
+                totalBalance
+              }
+            }
+          }
+        }
+      `,
+      variables,
+    });
+    const conn = res.data?.address?.balances;
+    for (const node of conn?.nodes ?? []) {
+      out.push({
+        coinType: node.coinType.repr,
+        coinObjectCount: node.coinObjectCount,
+        totalBalance: node.totalBalance ?? "0",
+        // GraphQL doesn't expose lockedBalance; preserve the JSON-RPC
+        // shape with an empty record.
+        lockedBalance: {},
+      });
+    }
+    if (conn?.pageInfo?.hasNextPage && conn.pageInfo.endCursor) {
+      cursor = conn.pageInfo.endCursor;
+    } else {
+      hasMore = false;
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Cat 4: Coins — reconstruct CoinStruct from `0x2::coin::Coin<T>` objects.
+// ---------------------------------------------------------------------------
+
+interface RawCoinNode {
+  address: string;
+  version: number | string;
+  digest: string;
+  contents: { type: { repr: string }; json: unknown };
+  previousTransaction: { digest: string } | null;
+}
+
+function buildCoinStruct(
+  node: RawCoinNode,
+  fallbackCoinType?: string,
+): CoinStruct {
+  const json = (node.contents.json ?? {}) as { balance?: string };
+  // Move type "0x2::coin::Coin<INNER>" — extract INNER for `coinType`.
+  let coinType = fallbackCoinType ?? "";
+  if (!coinType) {
+    const t = node.contents.type.repr;
+    const open = t.indexOf("<");
+    const close = t.lastIndexOf(">");
+    if (open >= 0 && close > open) {
+      coinType = t.slice(open + 1, close);
+    } else {
+      coinType = t;
+    }
+  }
+  return {
+    balance: json.balance ?? "0",
+    coinObjectId: node.address,
+    coinType,
+    digest: node.digest,
+    previousTransaction: node.previousTransaction?.digest ?? "",
+    version: String(node.version),
+  };
+}
+
+/**
+ * Fetch coins of a specific type owned by an address (one page).
+ */
+export async function getCoinsOfType(
+  owner: string,
+  coinType: string,
+  cursor: string | null = null,
+): Promise<PaginatedCoins> {
+  const client = getGraphQLClient();
+  const wrapped = `0x2::coin::Coin<${coinType}>`;
+  const res = await client.query<{
+    address: {
+      objects: GqlConnection<RawCoinNode>;
+    } | null;
+  }>({
+    query: /* GraphQL */ `
+      query getCoinsOfType(
+        $owner: SuiAddress!
+        $type: String!
+        $cursor: String
+      ) {
+        address(address: $owner) {
+          objects(filter: { type: $type }, after: $cursor) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              address
+              version
+              digest
+              contents {
+                type {
+                  repr
+                }
+                json
+              }
+              previousTransaction {
+                digest
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: { owner, type: wrapped, cursor },
+  });
+  const conn = res.data?.address?.objects;
+  const data: CoinStruct[] = (conn?.nodes ?? []).map((n) =>
+    buildCoinStruct(n, coinType),
+  );
+  return {
+    data,
+    hasNextPage: conn?.pageInfo?.hasNextPage ?? false,
+    nextCursor: conn?.pageInfo?.endCursor ?? null,
+  };
+}
+
+/**
+ * Fetch ALL coins owned by an address across coin types.
+ * (Single page — the legacy `getAllCoins` is also paginated; callers
+ * that need full coverage can iterate with `cursor`.)
+ */
+export async function getAllCoinsForOwner(
+  owner: string,
+  cursor: string | null = null,
+): Promise<PaginatedCoins> {
+  const client = getGraphQLClient();
+  // Filter by `0x2::coin::Coin` (the prefix without generic args) so we
+  // catch every Coin variant in a single query.
+  const res = await client.query<{
+    address: {
+      objects: GqlConnection<RawCoinNode>;
+    } | null;
+  }>({
+    query: /* GraphQL */ `
+      query getAllCoins($owner: SuiAddress!, $cursor: String) {
+        address(address: $owner) {
+          objects(filter: { type: "0x2::coin::Coin" }, after: $cursor) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              address
+              version
+              digest
+              contents {
+                type {
+                  repr
+                }
+                json
+              }
+              previousTransaction {
+                digest
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: { owner, cursor },
+  });
+  const conn = res.data?.address?.objects;
+  const data: CoinStruct[] = (conn?.nodes ?? []).map((n) => buildCoinStruct(n));
+  return {
+    data,
+    hasNextPage: conn?.pageInfo?.hasNextPage ?? false,
+    nextCursor: conn?.pageInfo?.endCursor ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cat 5: Epoch — current epoch as a string.
+// ---------------------------------------------------------------------------
+
+/** Get the current epoch number as a string (matches JSON-RPC). */
+export async function getCurrentEpoch(): Promise<string> {
+  const client = getGraphQLClient();
+  const res = await client.query<{
+    epoch: { epochId: number | string } | null;
+  }>({
+    query: /* GraphQL */ `
+      query getCurrentEpoch {
+        epoch {
+          epochId
+        }
+      }
+    `,
+    variables: {},
+  });
+  const id = res.data?.epoch?.epochId;
+  if (id === undefined || id === null) {
+    throw new Error("epoch.epochId not returned by GraphQL");
+  }
+  return String(id);
+}
+
+// ---------------------------------------------------------------------------
+// Cat 2: Events — paginated query by Move event type. Returns a
+// PaginatedEvents-shaped result so the existing Events.getEvents loop
+// in `events.ts` doesn't need to change.
+// ---------------------------------------------------------------------------
+
+export interface PaginatedMoveEvents {
+  data: SuiEvent[];
+  hasNextPage: boolean;
+  nextCursor: string | null;
+}
+
+/**
+ * Query one page of events filtered by Move event type
+ * (e.g. `<pkg>::events::Event<<pkg>::liquid_staking::MintEvent>`).
+ *
+ * GraphQL cursors are opaque strings, so pagination here stays purely in
+ * GraphQL cursor-space instead of trying to map cursors to EventId.
+ */
+export async function queryMoveEvents(
+  eventType: string,
+  cursor: string | null = null,
+): Promise<PaginatedMoveEvents> {
+  const client = getGraphQLClient();
+
+  const res = await client.query<{
+    events: GqlConnection<{
+      sender: { address: string } | null;
+      timestamp: string | null;
+      sequenceNumber: number | string;
+      transaction: { digest: string | null } | null;
+      contents: { type: { repr: string }; json: unknown };
+    }>;
+  }>({
+    query: /* GraphQL */ `
+      query queryMoveEvents($type: String!, $after: String) {
+        events(filter: { type: $type }, first: 50, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            sender {
+              address
+            }
+            timestamp
+            sequenceNumber
+            transaction {
+              digest
+            }
+            contents {
+              type {
+                repr
+              }
+              json
+            }
+          }
+        }
+      }
+    `,
+    variables: { type: eventType, after: cursor },
+  });
+  if (res.errors?.length) {
+    throw new Error(
+      `queryMoveEvents failed: ${res.errors.map((e) => e.message).join("; ")}`,
+    );
+  }
+
+  const conn = res.data?.events;
+  const data: SuiEvent[] = (conn?.nodes ?? []).map((node) => {
+    const ts = node.timestamp ? Date.parse(node.timestamp) : NaN;
+    const evt = {
+      id: {
+        txDigest: node.transaction?.digest ?? "",
+        eventSeq: String(node.sequenceNumber),
+      },
+      // packageId/transactionModule aren't used by stsui-sdk consumers,
+      // but we fill them best-effort from the type string for shape-parity.
+      packageId: node.contents.type.repr.split("::")[0] ?? "",
+      transactionModule: node.contents.type.repr.split("::")[1] ?? "",
+      sender: node.sender?.address ?? "",
+      type: node.contents.type.repr,
+      parsedJson: node.contents.json,
+      bcs: "",
+      bcsEncoding: "base64",
+      timestampMs: Number.isFinite(ts) ? String(ts) : null,
+    } as SuiEvent;
+    return evt;
+  });
+  return {
+    data,
+    hasNextPage: conn?.pageInfo?.hasNextPage ?? false,
+    nextCursor: conn?.pageInfo?.endCursor ?? null,
+  };
+}

--- a/src/common/client.ts
+++ b/src/common/client.ts
@@ -1,14 +1,16 @@
 // src/sui-sdk/client.ts
 
-/* This file contains the setup for the Sui Client, implemented as a singleton
+/* This file contains the setup for the Sui Client, implemented as a singleton.
+ *
+ * v0.1.x GraphQL migration: the SDK's internal reads now go through
+ * `src/common/graphql.ts` (`getGraphQLClient`). The legacy SuiClient
+ * accessors below remain for backward compatibility — most importantly
+ * for `Transaction.build()` resolution and for callers that need a
+ * SuiClient for their own purposes — but are marked `@deprecated`.
  */
 
-import {
-  getFullnodeUrl,
-  MultiGetObjectsParams,
-  SuiClient,
-  SuiObjectResponse,
-} from "@mysten/sui/client";
+import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
+import { multiGetObjectsFlat, type FlatObject } from "./blockchain.js";
 
 // Lazy initialization for the SuiClient instance
 let suiClientInstance: SuiClient | undefined = undefined;
@@ -17,6 +19,10 @@ let suiNodeUrl: string | undefined = undefined;
 /**
  * Get the current Sui node URL.
  * If no URL has been set, it defaults to the mainnet full node URL.
+ *
+ * @deprecated The SDK no longer uses JSON-RPC for reads. Use the
+ *   GraphQL singleton via `getGraphQLClient()` / `setGraphQLUrl()` for
+ *   new code; this accessor is kept for legacy callers.
  */
 export function getSuiNodeUrl(): string {
   suiNodeUrl = suiNodeUrl ? suiNodeUrl : getFullnodeUrl("mainnet");
@@ -26,6 +32,10 @@ export function getSuiNodeUrl(): string {
 /**
  * Get the SuiClient instance.
  * If a new URL has been set via setSuiNodeUrl, it will create a new instance with the updated URL.
+ *
+ * Still useful internally for `Transaction.build()` and externally for
+ * callers that want to sign/execute transactions; the SDK's read paths
+ * no longer go through this client.
  */
 export function getSuiClient(rpcNodeUrl?: string): SuiClient {
   if (rpcNodeUrl) {
@@ -45,6 +55,10 @@ export function getSuiClient(rpcNodeUrl?: string): SuiClient {
  * This will invalidate the current SuiClient instance, ensuring that
  * the next call to getSuiClient returns a new instance with the updated URL.
  *
+ * @deprecated GraphQL reads use a separate URL — see `setGraphQLUrl()`.
+ *   This setter only affects the legacy SuiClient used for transaction
+ *   signing/building.
+ *
  * @param rpcNodeUrl - The new RPC URL for the Sui client.
  */
 export function setSuiNodeUrl(rpcNodeUrl: string) {
@@ -56,13 +70,10 @@ export function setSuiNodeUrl(rpcNodeUrl: string) {
 
 /**
  * Set a new SuiClient instance with the specified RPC node URL.
- * This function directly creates a new instance of the SuiClient, overriding the existing instance
- * and using the provided URL for future requests.
  *
- * If the RPC node URL is different from the currently stored URL, a new instance of SuiClient will
- * be created and assigned, allowing the client to communicate with a new Sui node.
- *
- * @param rpcNodeUrl - The new RPC URL to be used for the SuiClient.
+ * @deprecated See `setSuiNodeUrl` — this setter only affects the legacy
+ *   SuiClient used for transaction signing/building. Use
+ *   `setGraphQLUrl()` for read endpoints.
  */
 export function setSuiClient(rpcNodeUrl: string) {
   if (suiNodeUrl !== rpcNodeUrl) {
@@ -75,19 +86,29 @@ export function setSuiClient(rpcNodeUrl: string) {
 
 /**
  * Set a custom SuiClient instance.
- * This function directly assigns the provided SuiClient instance to the global variable,
- * allowing for direct manipulation of the client instance.
  *
- * @param suiClient - The custom SuiClient instance to be set.
+ * @deprecated See `setSuiNodeUrl` — only the legacy SuiClient is
+ *   replaced. Use `setGraphQLUrl()` to point reads at a custom endpoint.
  */
 export const setCustomSuiClient = (suiClient: SuiClient) => {
   suiClientInstance = suiClient;
 };
 
-export function getMultiObjects(
-  input: MultiGetObjectsParams,
-): Promise<SuiObjectResponse[]> {
-  const suiClient = getSuiClient();
-  const res = suiClient.multiGetObjects(input);
-  return res;
+/**
+ * Batch fetch flat shapes for the given object ids.
+ *
+ * v0.1.x note: previously returned `SuiObjectResponse[]` (the JSON-RPC
+ * shape). Now returns `(FlatObject | null)[]` — flat fields with
+ * `objectId / version / digest / type / fields`. See
+ * STSUI_GRAPHQL_MIGRATION.md for the field-by-field mapping.
+ *
+ * The `options` parameter is preserved for source-compat with the old
+ * `MultiGetObjectsParams` signature but is ignored — GraphQL always
+ * includes contents.
+ */
+export async function getMultiObjects(input: {
+  ids: string[];
+  options?: unknown;
+}): Promise<(FlatObject | null)[]> {
+  return multiGetObjectsFlat(input.ids);
 }

--- a/src/common/client.ts
+++ b/src/common/client.ts
@@ -9,8 +9,14 @@
  * SuiClient for their own purposes — but are marked `@deprecated`.
  */
 
-import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
-import { multiGetObjectsFlat, type FlatObject } from "./blockchain.js";
+import {
+  getFullnodeUrl,
+  MultiGetObjectsParams,
+  SuiClient,
+  SuiObjectResponse,
+} from "@mysten/sui/client";
+
+export { multiGetObjectsGraphql, type FlatObject } from "./blockchain.js";
 
 // Lazy initialization for the SuiClient instance
 let suiClientInstance: SuiClient | undefined = undefined;
@@ -95,20 +101,18 @@ export const setCustomSuiClient = (suiClient: SuiClient) => {
 };
 
 /**
- * Batch fetch flat shapes for the given object ids.
+ * Batch fetch JSON-RPC `SuiObjectResponse` shapes for the given object ids.
  *
- * v0.1.x note: previously returned `SuiObjectResponse[]` (the JSON-RPC
- * shape). Now returns `(FlatObject | null)[]` — flat fields with
- * `objectId / version / digest / type / fields`. See
- * STSUI_GRAPHQL_MIGRATION.md for the field-by-field mapping.
- *
- * The `options` parameter is preserved for source-compat with the old
- * `MultiGetObjectsParams` signature but is ignored — GraphQL always
- * includes contents.
+ * @deprecated v0.1.x of the SDK migrated all internal reads to GraphQL.
+ *   This helper still uses `SuiClient.multiGetObjects` so existing
+ *   callers remain source-compatible. New code should call
+ *   `multiGetObjectsGraphql(ids)` (re-exported from this module), which
+ *   returns the GraphQL-native flat object shape
+ *   `{ objectId, version, digest, type, fields }`.
  */
-export async function getMultiObjects(input: {
-  ids: string[];
-  options?: unknown;
-}): Promise<(FlatObject | null)[]> {
-  return multiGetObjectsFlat(input.ids);
+export function getMultiObjects(
+  input: MultiGetObjectsParams,
+): Promise<SuiObjectResponse[]> {
+  const suiClient = getSuiClient();
+  return suiClient.multiGetObjects(input);
 }

--- a/src/common/events.ts
+++ b/src/common/events.ts
@@ -1,5 +1,3 @@
-import { EventId, PaginatedEvents } from "@mysten/sui/client";
-import { getSuiClient } from "./client.js";
 import { getConf } from "./ids.js";
 import {
   CommonEventParams,
@@ -10,6 +8,7 @@ import {
   MintEvent,
   RedeemEvent,
 } from "./types.js";
+import { queryMoveEvents, type PaginatedMoveEvents } from "./blockchain.js";
 
 export class Events {
   static async getEpochChangeEvents(
@@ -50,16 +49,15 @@ export class Events {
       return events;
     }
     let hasNext = true;
-    let startCursor: EventId | null | undefined;
+    let startCursor: string | null = null;
+
+    const eventType = `${getConf().STSUI_FIRST_PACKAGE_ID}::events::Event<${getConf().STSUI_FIRST_PACKAGE_ID}::liquid_staking::${eventName}>`;
 
     while (hasNext) {
-      const eventData: PaginatedEvents = await getSuiClient().queryEvents({
-        cursor: startCursor,
-        order: "descending",
-        query: {
-          MoveEventType: `${getConf().STSUI_FIRST_PACKAGE_ID}::events::Event<${getConf().STSUI_FIRST_PACKAGE_ID}::liquid_staking::${eventName}>`,
-        },
-      });
+      const eventData: PaginatedMoveEvents = await queryMoveEvents(
+        eventType,
+        startCursor,
+      );
 
       for (const eve of eventData.data) {
         const event = {
@@ -82,7 +80,7 @@ export class Events {
         events.push(event);
       }
       hasNext = eventData.hasNextPage;
-      startCursor = eventData.nextCursor;
+      startCursor = eventData.nextCursor ?? null;
     }
 
     return events;

--- a/src/common/graphql.ts
+++ b/src/common/graphql.ts
@@ -8,15 +8,24 @@
  */
 
 import { SuiGraphQLClient } from "@mysten/sui/graphql";
+import { getConfEnv } from "./ids.js";
 
-const DEFAULT_GRAPHQL_URL = "https://graphql.mainnet.sui.io/graphql";
+const GRAPHQL_URLS = {
+  production: "https://graphql.mainnet.sui.io/graphql",
+  testing: "https://graphql.testnet.sui.io/graphql",
+} as const;
 
 let graphqlClientInstance: SuiGraphQLClient | undefined = undefined;
 let graphqlUrl: string | undefined = undefined;
+let activeClientUrl: string | undefined = undefined;
 
-/** Get the current GraphQL URL (defaults to mainnet). */
+function getDefaultGraphQLUrl(): string {
+  return GRAPHQL_URLS[getConfEnv()];
+}
+
+/** Get the current GraphQL URL (defaults to active conf network). */
 export function getGraphQLUrl(): string {
-  return graphqlUrl ?? DEFAULT_GRAPHQL_URL;
+  return graphqlUrl ?? getDefaultGraphQLUrl();
 }
 
 /**
@@ -27,10 +36,13 @@ export function getGraphQLClient(url?: string): SuiGraphQLClient {
   if (url && url !== graphqlUrl) {
     setGraphQLUrl(url);
   }
-  if (!graphqlClientInstance) {
+
+  const resolvedUrl = getGraphQLUrl();
+  if (!graphqlClientInstance || activeClientUrl !== resolvedUrl) {
     graphqlClientInstance = new SuiGraphQLClient({
-      url: getGraphQLUrl(),
+      url: resolvedUrl,
     });
+    activeClientUrl = resolvedUrl;
   }
   return graphqlClientInstance;
 }
@@ -40,5 +52,6 @@ export function setGraphQLUrl(url: string) {
   if (graphqlUrl !== url) {
     graphqlUrl = url;
     graphqlClientInstance = undefined;
+    activeClientUrl = undefined;
   }
 }

--- a/src/common/graphql.ts
+++ b/src/common/graphql.ts
@@ -1,0 +1,44 @@
+/**
+ * GraphQL client singleton for stsui-sdk.
+ *
+ * Mirrors the lazy-init / replaceable-singleton pattern of the legacy
+ * SuiClient singleton in `client.ts`. All internal SDK reads route
+ * through this. Public API consumers can override the URL via
+ * `setGraphQLUrl()` if they want to point at a custom endpoint.
+ */
+
+import { SuiGraphQLClient } from "@mysten/sui/graphql";
+
+const DEFAULT_GRAPHQL_URL = "https://graphql.mainnet.sui.io/graphql";
+
+let graphqlClientInstance: SuiGraphQLClient | undefined = undefined;
+let graphqlUrl: string | undefined = undefined;
+
+/** Get the current GraphQL URL (defaults to mainnet). */
+export function getGraphQLUrl(): string {
+  return graphqlUrl ?? DEFAULT_GRAPHQL_URL;
+}
+
+/**
+ * Get the SuiGraphQLClient singleton. If `url` is provided and differs
+ * from the current URL, the singleton is replaced.
+ */
+export function getGraphQLClient(url?: string): SuiGraphQLClient {
+  if (url && url !== graphqlUrl) {
+    setGraphQLUrl(url);
+  }
+  if (!graphqlClientInstance) {
+    graphqlClientInstance = new SuiGraphQLClient({
+      url: getGraphQLUrl(),
+    });
+  }
+  return graphqlClientInstance;
+}
+
+/** Replace the GraphQL URL and invalidate the singleton. */
+export function setGraphQLUrl(url: string) {
+  if (graphqlUrl !== url) {
+    graphqlUrl = url;
+    graphqlClientInstance = undefined;
+  }
+}

--- a/src/common/ids.ts
+++ b/src/common/ids.ts
@@ -1,4 +1,7 @@
-const CONF_ENV = "production";
+type ConfEnv = "testing" | "production";
+
+const DEFAULT_CONF_ENV: ConfEnv = "production";
+let confEnv: ConfEnv = DEFAULT_CONF_ENV;
 
 const conf = {
   testing: {
@@ -17,6 +20,13 @@ const conf = {
 
     COLLECTION_FEE_CAP_ID:
       "0x26c607cdbb2063d6eb2900e63c80181f482996d65bf96c986d76c1264099b88a",
+
+    // Meta is currently production-only; keep keys present so config shape
+    // remains stable when switching environments.
+    META_PACKAGE_ID: "",
+    META_ADMIN_CAP: "",
+    META_OBJECT: "",
+    META_UPGRADE_CAP: "",
 
     SUI_SYSTEM_STATE_OBJECT_ID: "0x5",
 
@@ -70,6 +80,14 @@ const conf = {
   },
 };
 
+export function getConfEnv(): ConfEnv {
+  return confEnv;
+}
+
+export function setConf(env: ConfEnv) {
+  confEnv = env;
+}
+
 export function getConf() {
-  return conf[CONF_ENV];
+  return conf[confEnv];
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,44 +1,26 @@
+/**
+ * Flat representation of the on-chain `LiquidStakingInfo<LST>` object.
+ *
+ * **Note (v0.1.x GraphQL migration):** earlier versions of this SDK
+ * returned the legacy JSON-RPC `getObject({showContent: true})` shape,
+ * which wraps every nested Move struct in `{ type, fields }`. After the
+ * migration we return GraphQL's natural flat shape — the deep `.content
+ * .fields.X.fields.Y.fields.Z` chains collapse to `.fields.X.Y.Z`.
+ */
 export type LiquidStakingInfo = {
   objectId: string;
   version: string;
   digest: string;
-  content: {
-    dataType: string;
-    type: string;
-    hasPublicTransfer: boolean;
-    fields: {
-      accrued_spread_fees: string;
-      fees: string;
-      fee_config: {
-        type: string;
-        fields: {
-          element: {
-            type: string;
-            fields: FeeConfig;
-          };
-        };
-        //add more fields as per use
-      };
-      lst_treasury_cap: {
-        type: string;
-        fields: {
-          total_supply: {
-            type: string;
-            fields: {
-              value: string;
-            };
-          };
-        };
-      };
-      storage: {
-        type: string;
-        fields: {
-          last_refresh_epoch: string;
-          total_sui_supply: string;
-          total_weight: string;
-          // add more as per use
-        };
-      };
+  type: string;
+  fields: {
+    accrued_spread_fees: string;
+    fees: string;
+    fee_config: { element: FeeConfig };
+    lst_treasury_cap: { total_supply: { value: string } };
+    storage: {
+      last_refresh_epoch: string;
+      total_sui_supply: string;
+      total_weight: string;
     };
   };
 };
@@ -135,25 +117,20 @@ export type EventType =
   | RedeemEvent
   | FlashStakeEvent
   | EpochChangedEvent;
+/**
+ * Flat representation of the on-chain Meta object. Same v0.1.x shape
+ * change as `LiquidStakingInfo` — no `content.fields.*.fields.*` wrap.
+ */
 export type Meta = {
   objectId: string;
   version: string;
   digest: string;
-  content: {
-    dataType: string;
-    type: string;
-    hasPublicTransfer: boolean;
-    fields: {
-      last_update_event_timestamp: string;
-      stakers: {
-        type: string;
-        fields: {
-          id: {
-            id: string;
-          };
-          size: string;
-        };
-      };
+  type: string;
+  fields: {
+    last_update_event_timestamp: string;
+    stakers: {
+      id: string;
+      size: string;
     };
   };
 };

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,5 +1,4 @@
 import {
-  getSuiClient,
   getConf,
   LiquidStakingInfo,
   FeeConfig,
@@ -12,6 +11,7 @@ import { bech32 } from "bech32";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction } from "@mysten/sui/transactions";
 import { SimpleCache } from "./simpleCache.js";
+import { getCurrentEpoch, getObjectFlat } from "./blockchain.js";
 
 export async function stSuiExchangeRate(
   lstInfoId: string,
@@ -23,10 +23,10 @@ export async function stSuiExchangeRate(
     return "0";
   }
   const totalSuiSupply = new Decimal(
-    lstInfo.content.fields.storage.fields.total_sui_supply.toString(),
-  ).minus(new Decimal(lstInfo.content.fields.accrued_spread_fees));
+    lstInfo.fields.storage.total_sui_supply.toString(),
+  ).minus(new Decimal(lstInfo.fields.accrued_spread_fees));
   const totalStSuiSupply = new Decimal(
-    lstInfo.content.fields.lst_treasury_cap.fields.total_supply.fields.value.toString(),
+    lstInfo.fields.lst_treasury_cap.total_supply.value.toString(),
   );
   if (totalStSuiSupply.eq(0)) {
     return "0";
@@ -60,16 +60,15 @@ export async function getLstInfo(
   }
   lstInfoPromise = (async () => {
     try {
-      const lstInfo = (
-        await getSuiClient().getObject({
-          id: lstInfoId,
-          options: {
-            showContent: true,
-          },
-        })
-      ).data as LiquidStakingInfo;
-
-      // Cache the investor object
+      const flat = await getObjectFlat<LiquidStakingInfo["fields"]>(lstInfoId);
+      if (!flat) return undefined;
+      const lstInfo: LiquidStakingInfo = {
+        objectId: flat.objectId,
+        version: flat.version,
+        digest: flat.digest,
+        type: flat.type,
+        fields: flat.fields,
+      };
       lsInfoCache.set(cacheKey, lstInfo);
       return lstInfo;
     } catch (e) {
@@ -87,15 +86,15 @@ export async function getLstInfo(
 }
 
 export async function getMeta(): Promise<Meta | undefined> {
-  const meta = (
-    await getSuiClient().getObject({
-      id: getConf().META_OBJECT,
-      options: {
-        showContent: true,
-      },
-    })
-  ).data as Meta;
-  return meta;
+  const flat = await getObjectFlat<Meta["fields"]>(getConf().META_OBJECT);
+  if (!flat) return undefined;
+  return {
+    objectId: flat.objectId,
+    version: flat.version,
+    digest: flat.digest,
+    type: flat.type,
+    fields: flat.fields,
+  };
 }
 
 export const stStuiCirculationSupply = async (
@@ -109,7 +108,7 @@ export const stStuiCirculationSupply = async (
       return "0";
     }
     const totalStSuiSupply = new Decimal(
-      lstInfo.content.fields.lst_treasury_cap.fields.total_supply.fields.value.toString(),
+      lstInfo.fields.lst_treasury_cap.total_supply.value.toString(),
     );
     const suiPrice = await getLatestPrices(["SUI/USD"], false);
     const stSuiExchRate = await stSuiExchangeRate(lstInfoId, ignoreCache);
@@ -137,8 +136,8 @@ export const fetchTotalSuiStaked = async (
       return "0";
     }
     const totalSuiStaked = new Decimal(
-      lstInfo.content.fields.storage.fields.total_sui_supply.toString(),
-    ).minus(new Decimal(lstInfo.content.fields.accrued_spread_fees));
+      lstInfo.fields.storage.total_sui_supply.toString(),
+    ).minus(new Decimal(lstInfo.fields.accrued_spread_fees));
     return totalSuiStaked.div(10 ** 9).toString();
   } catch (error) {
     console.log("error", error);
@@ -148,8 +147,7 @@ export const fetchTotalSuiStaked = async (
 
 export const fetchCurrentStSuiEpoch = async () => {
   try {
-    const currentEpoch = (await getSuiClient().getLatestSuiSystemState()).epoch;
-    return currentEpoch;
+    return await getCurrentEpoch();
   } catch (error) {
     console.log("error", error);
     return "0";
@@ -219,7 +217,7 @@ export const fetchTotalStakers = async (): Promise<string> => {
   try {
     const meta = await getMeta();
     if (meta) {
-      return meta.content.fields.stakers.fields.size.toString();
+      return meta.fields.stakers.size.toString();
     } else {
       console.error("error: couldnt fetch meta");
       return "0";
@@ -239,7 +237,7 @@ export const updateTotalStakers = async (): Promise<
       throw new Error("error couldnt fetch meta");
     }
     const e = Date.now();
-    const s = Number(meta.content.fields.last_update_event_timestamp) + 1;
+    const s = Number(meta.fields.last_update_event_timestamp) + 1;
     const mintEvents = await Events.getMintEvents({
       startTime: s,
       endTime: e,
@@ -280,7 +278,7 @@ export const getFees = async (
       console.error("couldnt fetch lst info object");
       return;
     }
-    return lstInfo.content.fields.fee_config.fields.element.fields as FeeConfig;
+    return lstInfo.fields.fee_config.element as FeeConfig;
   } catch (e) {
     console.error("error", e);
   }

--- a/src/stSui/redeem.ts
+++ b/src/stSui/redeem.ts
@@ -2,9 +2,29 @@ import {
   Transaction,
   TransactionObjectArgument,
 } from "@mysten/sui/transactions";
-import { getConf, getSuiClient, stSuiExchangeRate } from "../index.js";
+import { getConf, stSuiExchangeRate } from "../index.js";
 import { CoinStruct } from "@mysten/sui/client";
 import { Decimal } from "decimal.js";
+import { getCoinsOfType } from "../common/blockchain.js";
+
+async function fetchAllCoinsOfType(
+  owner: string,
+  coinType: string,
+): Promise<CoinStruct[]> {
+  const all: CoinStruct[] = [];
+  let cursor: string | null = null;
+  let hasMore = true;
+  while (hasMore) {
+    const page = await getCoinsOfType(owner, coinType, cursor);
+    all.push(...page.data);
+    if (page.hasNextPage && page.nextCursor) {
+      cursor = page.nextCursor;
+    } else {
+      hasMore = false;
+    }
+  }
+  return all;
+}
 
 export async function redeem(
   lstInfo: string,
@@ -14,31 +34,7 @@ export async function redeem(
 ): Promise<Transaction> {
   const txb = new Transaction();
 
-  let coins: CoinStruct[] = [];
-
-  let currentCursor: string | null | undefined = null;
-
-  do {
-    const response = await getSuiClient().getCoins({
-      owner: address,
-      coinType: lstCoinType,
-      cursor: currentCursor,
-    });
-
-    coins = coins.concat(response.data);
-
-    // Check if there's a next page
-    if (response.hasNextPage && response.nextCursor) {
-      currentCursor = response.nextCursor;
-    } else {
-      // No more pages available
-      // console.log("No more receipts available.");
-      break;
-    }
-  } while (
-    //eslint-disable-next-line no-constant-condition
-    true
-  );
+  const coins = await fetchAllCoinsOfType(address, lstCoinType);
 
   if (coins.length == 0) {
     throw new Error("No coin");
@@ -76,30 +72,9 @@ export async function redeemTx(
 }> {
   if (!txb) txb = new Transaction();
 
-  let coins: CoinStruct[] = [];
-
-  let currentCursor: string | null | undefined = null;
-
-  do {
-    const response = await getSuiClient().getCoins({
-      owner: options.address,
-      coinType: getConf().STSUI_COIN_TYPE,
-      cursor: currentCursor,
-    });
-
-    coins = coins.concat(response.data);
-
-    // Check if there's a next page
-    if (response.hasNextPage && response.nextCursor) {
-      currentCursor = response.nextCursor;
-    } else {
-      // No more pages available
-      // console.log("No more receipts available.");
-      break;
-    }
-  } while (
-    //eslint-disable-next-line no-constant-condition
-    true
+  const coins = await fetchAllCoinsOfType(
+    options.address,
+    getConf().STSUI_COIN_TYPE,
   );
 
   if (coins.length == 0) {

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.esm.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "scripts/migration-snapshot.ts"],
+  "exclude": ["src/__tests__"]
+}


### PR DESCRIPTION
- Migrated internal read stack to GraphQL with a minimal singleton-based design and backward-compatible SDK usage patterns.
- Reworked core data access (getObject, balances, coins, events, epoch) to parse GraphQL responses into expected SDK outputs.
- Fixed functional regressions discovered during migration (including getWalletCoins) and corrected event query schema usage.
- Added comprehensive before/after snapshot coverage for exposed SDK functions and normalized tx skeleton diff checks.
- Updated README + migration doc, cleaned lint/type/test flow, and verified semantic parity with only expected deltas.