### PR TITLE
feat: address-balance-aware stSUI redeem via coinWithBalance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alphafi/stsui-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alphafi/stsui-sdk",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@types/bn.js": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphafi/stsui-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/src/stSui/redeem.ts
+++ b/src/stSui/redeem.ts
@@ -3,28 +3,7 @@ import {
   TransactionObjectArgument,
 } from "@mysten/sui/transactions";
 import { getConf, stSuiExchangeRate } from "../index.js";
-import { CoinStruct } from "@mysten/sui/jsonRpc";
 import { Decimal } from "decimal.js";
-import { getCoinsOfType } from "../common/blockchain.js";
-
-async function fetchAllCoinsOfType(
-  owner: string,
-  coinType: string,
-): Promise<CoinStruct[]> {
-  const all: CoinStruct[] = [];
-  let cursor: string | null = null;
-  let hasMore = true;
-  while (hasMore) {
-    const page = await getCoinsOfType(owner, coinType, cursor);
-    all.push(...page.data);
-    if (page.hasNextPage && page.nextCursor) {
-      cursor = page.nextCursor;
-    } else {
-      hasMore = false;
-    }
-  }
-  return all;
-}
 
 export async function redeem(
   lstInfo: string,
@@ -33,18 +12,16 @@ export async function redeem(
   address: string,
 ): Promise<Transaction> {
   const txb = new Transaction();
+  txb.setSender(address);
 
-  const coins = await fetchAllCoinsOfType(address, lstCoinType);
-
-  if (coins.length == 0) {
-    throw new Error("No coin");
-  }
-  const [coin] = txb.splitCoins(txb.object(coins[0].coinObjectId), [0]);
-  txb.mergeCoins(
-    coin,
-    coins.map((c) => c.coinObjectId),
-  );
-  const [stSuiCoin] = txb.splitCoins(coin, [stSuiAmount]);
+  // Source the exact stSUI amount from address balance + coin objects. Resolved
+  // at build time via @mysten/sui's coinWithBalance intent, so the tx must be
+  // built with a v2 client (`.core` available) — our SuiJsonRpcClient and the
+  // wallet's dapp-kit client both qualify.
+  const stSuiCoin = txb.coin({
+    type: lstCoinType,
+    balance: BigInt(stSuiAmount),
+  });
 
   const [sui] = txb.moveCall({
     target: getConf().STSUI_LATEST_PACKAGE_ID + "::liquid_staking::redeem",
@@ -55,8 +32,7 @@ export async function redeem(
     ],
     typeArguments: [lstCoinType],
   });
-  txb.transferObjects([sui, coin], address);
-  txb.setSender(address);
+  txb.transferObjects([sui], address);
   return txb;
 }
 
@@ -71,21 +47,14 @@ export async function redeemTx(
   amountOut: string;
 }> {
   if (!txb) txb = new Transaction();
+  // coinWithBalance (below) resolves against the tx sender at build time.
+  txb.setSenderIfNotSet(options.address);
 
-  const coins = await fetchAllCoinsOfType(
-    options.address,
-    getConf().STSUI_COIN_TYPE,
-  );
-
-  if (coins.length == 0) {
-    throw new Error("No coin");
-  }
-  const [coin] = txb.splitCoins(txb.object(coins[0].coinObjectId), [0]);
-  txb.mergeCoins(
-    coin,
-    coins.map((c) => c.coinObjectId),
-  );
-  const [stSuiCoin] = txb.splitCoins(coin, [stSuiAmount]);
+  // Source the exact stSUI amount from address balance + coin objects.
+  const stSuiCoin = txb.coin({
+    type: getConf().STSUI_COIN_TYPE,
+    balance: BigInt(stSuiAmount),
+  });
 
   const [sui] = txb.moveCall({
     target: getConf().STSUI_LATEST_PACKAGE_ID + "::liquid_staking::redeem",
@@ -103,9 +72,11 @@ export async function redeemTx(
   const amount_decimal = new Decimal(stSuiAmount);
   const amountOut = amount_decimal.mul(exchangeRate);
   return {
+    // No leftover stSUI coin: coinWithBalance sources the exact amount, so any
+    // unused balance stays in the user's address balance / coin objects.
     tx: txb,
     coinOut: sui,
-    remainingLSTCoin: coin,
+    remainingLSTCoin: undefined,
     amountOut: amountOut.toString(),
   };
 }

--- a/src/stSui/redeem.ts
+++ b/src/stSui/redeem.ts
@@ -12,12 +12,6 @@ export async function redeem(
   address: string,
 ): Promise<Transaction> {
   const txb = new Transaction();
-  txb.setSender(address);
-
-  // Source the exact stSUI amount from address balance + coin objects. Resolved
-  // at build time via @mysten/sui's coinWithBalance intent, so the tx must be
-  // built with a v2 client (`.core` available) — our SuiJsonRpcClient and the
-  // wallet's dapp-kit client both qualify.
   const stSuiCoin = txb.coin({
     type: lstCoinType,
     balance: BigInt(stSuiAmount),
@@ -33,6 +27,7 @@ export async function redeem(
     typeArguments: [lstCoinType],
   });
   txb.transferObjects([sui], address);
+  txb.setSender(address);
   return txb;
 }
 
@@ -72,8 +67,6 @@ export async function redeemTx(
   const amount_decimal = new Decimal(stSuiAmount);
   const amountOut = amount_decimal.mul(exchangeRate);
   return {
-    // No leftover stSUI coin: coinWithBalance sources the exact amount, so any
-    // unused balance stays in the user's address balance / coin objects.
     tx: txb,
     coinOut: sui,
     remainingLSTCoin: undefined,


### PR DESCRIPTION
## Summary

Makes stSUI `redeem` source funds from the user's **address balance + `Coin<T>` objects** instead of manually fetching and splitting coin objects.

## Changes

- `redeem` now sources the exact stSUI amount via `@mysten/sui`'s `coinWithBalance` intent (`txb.coin({ type, balance })`), resolved lazily at build time — drawing from BOTH the address-balance accumulator AND owned `Coin<T>` objects.
- Removes the manual `getCoinsOfType` + `splitCoins` plumbing and the leftover-coin transfer: `coinWithBalance` sources the exact amount, so any unused balance simply stays in the user's address balance / coin objects (no dangling zero/again-merged coin).
- Because `coinWithBalance` resolves at `build()` time, the transaction must be built with a v2 client that exposes `.core` (our `SuiJsonRpcClient` and the wallet's dapp-kit client both do).

## Test plan

- `npm ci && npm run build` — passes
- `npm test` — passes
