### PR TITLE
chore: upgrade @mysten/sui to 2.22.0 and remove legacy JSON-RPC client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
-        "@mysten/sui": "^2.17.0",
+        "@mysten/sui": "2.22.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.1",
         "eslint": "^9.14.0",
@@ -30,13 +30,13 @@
         "typescript-eslint": "^8.14.0"
       },
       "peerDependencies": {
-        "@mysten/sui": "^2.17.0"
+        "@mysten/sui": "^2.22.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
-      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.3.2.tgz",
+      "integrity": "sha512-Q1+pRlLhE31GOY/2c9BAEnFTNxO7Awtc6fhhEDlxyCBQ2N0IhD32cPVvPChrK9mwBNSgRdW/sF1kd2e0ojHj1Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -49,13 +49,13 @@
       }
     },
     "node_modules/@0no-co/graphqlsp": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.4.tgz",
-      "integrity": "sha512-Nt1DVHcZ08lKRKwhiU0amXH77fSdrO6DzyjLE0DkCxfbM/N1SAs32d76y1xtCzM5H9eT0iDS7SdksgRXWJu05g==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.17.3.tgz",
+      "integrity": "sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@gql.tada/internal": "^1.0.0",
+        "@gql.tada/internal": "^1.2.0",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
       },
       "peerDependencies": {
@@ -729,22 +729,22 @@
       }
     },
     "node_modules/@gql.tada/cli-utils": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.3.tgz",
-      "integrity": "sha512-3iQY5E/jvv3Lnh6D1Mh7zr+Bb9C/TGk1DHkm+lbIjQBnZAu2m+BcTcr1e3spUt6Aa6HG/xAN2XxpbWw9oZALEg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.9.2.tgz",
+      "integrity": "sha512-cVNs4v8ewLRYJfyAsaHbiAmd5Hm+zXEMvMhBksH58ZU87d6f8crsp2CQG6QtIqnJJw1q0CBWfWTZepGWNcL3QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/internal": "1.0.9",
+        "@0no-co/graphqlsp": "^1.17.3",
+        "@gql.tada/internal": "1.2.1",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
       },
       "peerDependencies": {
-        "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/svelte-support": "1.0.2",
-        "@gql.tada/vue-support": "1.0.2",
+        "@0no-co/graphqlsp": "^1.16.0",
+        "@gql.tada/svelte-support": "1.0.3",
+        "@gql.tada/vue-support": "1.0.3",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@gql.tada/svelte-support": {
@@ -756,17 +756,17 @@
       }
     },
     "node_modules/@gql.tada/internal": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.9.tgz",
-      "integrity": "sha512-Bp8yi+kLrzIJ3l5Dfxhz48H4OCH2LCX+pShaPcJgh+oiBt6clrjUKDYNDD3Z78aDQ3+Tyrxe4dd0MfLgpSLPPg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.2.1.tgz",
+      "integrity": "sha512-1kPMv9KRpD6mfVwtXK+iy43U/gi4bpr4ganfhPLD0TjxpbuVJm7CtZ9wMFdwy3FjLBFN2QhwscNnL7lRPHg4vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@0no-co/graphql.web": "^1.0.5"
+        "@0no-co/graphql.web": "^1.3.1"
       },
       "peerDependencies": {
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -1305,51 +1305,51 @@
       }
     },
     "node_modules/@mysten/bcs": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-2.0.5.tgz",
-      "integrity": "sha512-Dop9Xq36DPLlsmIDQZvUg4uJeBBxIGirgp2OXGaEff+mtLKFBoW2HnE3aSTSSpiMQH9XRhjwtiM16zFJhFqz0Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-2.1.0.tgz",
+      "integrity": "sha512-rIR/cDAqDfBDxmYEZXppN/on8gmh1OW0dYi/Bk2kMBZcYMTaBaEtEX1VR6g7HicVxuMbFAIP0/SQkdH7J9Y5dQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/utils": "^0.3.3",
-        "@scure/base": "^2.0.0"
+        "@mysten/utils": "^0.4.0",
+        "@scure/base": "^2.2.0"
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-2.17.0.tgz",
-      "integrity": "sha512-TrS1BCPm4V6rC69MBejmcqnKIyJ5t1iksax4XA9jWarZxAAp9LMmdxEBebejyDT/yAJxYIf3fNm5WBkHE2qnIw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-2.22.0.tgz",
+      "integrity": "sha512-M1iQM7C2NZuSafNF0SRaZtA+m7ggg6NUl3hg/2FAcl+NtL7qz8RoK7SO6NmgPmojH2trUJIex4TAnyItO45p2A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "^2.0.5",
-        "@mysten/utils": "^0.3.3",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
+        "@mysten/bcs": "^2.1.0",
+        "@mysten/utils": "^0.4.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "@protobuf-ts/grpcweb-transport": "^2.11.1",
         "@protobuf-ts/runtime": "^2.11.1",
         "@protobuf-ts/runtime-rpc": "^2.11.1",
-        "@scure/base": "^2.0.0",
-        "@scure/bip32": "^2.0.1",
-        "@scure/bip39": "^2.0.1",
-        "gql.tada": "^1.9.0",
-        "graphql": "^16.12.0",
+        "@scure/base": "^2.2.0",
+        "@scure/bip32": "^2.2.0",
+        "@scure/bip39": "^2.2.0",
+        "gql.tada": "^1.10.1",
+        "graphql": "^16.14.2",
         "poseidon-lite": "0.2.1",
-        "valibot": "^1.2.0"
+        "valibot": "^1.4.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@mysten/utils": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.3.3.tgz",
-      "integrity": "sha512-gVHn5toh24eXXLEyBknwwM2F/tbDgqPX0yj77KtHjuoYUallcQ9vSwGfGsAy39IcTB259Yprt/ZOEwdup+zrpA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-nHlXECBl9kE+AHF/aw5a7JVNizae8Kb71A4H18BV/sXd5/l2BaWNGWVatq05fzJo3hF78AWorDxa++1TgcBKWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@scure/base": "^2.0.0"
+        "@scure/base": "^2.2.0"
       }
     },
     "node_modules/@noble/curves": {
@@ -3153,23 +3153,23 @@
       }
     },
     "node_modules/gql.tada": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.9.2.tgz",
-      "integrity": "sha512-QxRHVpxtrOVdYXz6oavq0lBM+Zdp0swapLGJcD4SLpXDcsD337BHDFrzqqjfkbepv0sSAiO0LGabu1kI5D5Gyg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.11.2.tgz",
+      "integrity": "sha512-oBr7ShA5/TmcwOO7BZgN1SynX2rBU+/ltysB0zXc+NCBF+9YOg6MRzJcTfLjIqDKdcE3LGxpOl0l9hBbxmyzmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@0no-co/graphql.web": "^1.0.5",
-        "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/cli-utils": "1.7.3",
-        "@gql.tada/internal": "1.0.9"
+        "@0no-co/graphql.web": "^1.3.2",
+        "@0no-co/graphqlsp": "^1.17.3",
+        "@gql.tada/cli-utils": "1.9.2",
+        "@gql.tada/internal": "1.2.1"
       },
       "bin": {
         "gql-tada": "bin/cli.js",
         "gql.tada": "bin/cli.js"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -3180,9 +3180,9 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.1.tgz",
-      "integrity": "sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "description": "",
   "devDependencies": {
     "@eslint/js": "^9.15.0",
+    "@mysten/sui": "2.22.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.1",
     "eslint": "^9.14.0",
@@ -37,8 +38,7 @@
     "ts-jest": "^29.2.5",
     "typedoc": "^0.27.5",
     "typescript": "^5.6.3",
-    "typescript-eslint": "^8.14.0",
-    "@mysten/sui": "^2.17.0"
+    "typescript-eslint": "^8.14.0"
   },
   "dependencies": {
     "@types/bn.js": "^5.1.6",
@@ -47,9 +47,9 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "@mysten/sui": "^2.17.0"
+    "@mysten/sui": "^2.22.0"
   },
   "overrides": {
-    "@mysten/sui": "^2.17.0"
+    "@mysten/sui": "2.22.0"
   }
 }

--- a/src/common/client.ts
+++ b/src/common/client.ts
@@ -1,127 +1,29 @@
-// src/sui-sdk/client.ts
+// src/common/client.ts
 
-/* This file contains the setup for the Sui Client, implemented as a singleton.
+/* Sui client helpers.
  *
- * v0.1.x GraphQL migration: the SDK's internal reads now go through
- * `src/common/graphql.ts` (`getGraphQLClient`). The legacy SuiClient
- * accessors below remain for backward compatibility — most importantly
- * for `Transaction.build()` resolution and for callers that need a
- * SuiClient for their own purposes — but are marked `@deprecated`.
+ * The SDK's reads go through GraphQL (see `src/common/graphql.ts` and
+ * `src/common/blockchain.ts`). The legacy JSON-RPC `SuiClient` singleton and
+ * its accessors (`getSuiClient`, `setSuiClient`, `setSuiNodeUrl`,
+ * `setCustomSuiClient`, `getSuiNodeUrl`) have been removed — the SDK no longer
+ * constructs a JSON-RPC client. `getMultiObjects` now delegates to the
+ * GraphQL-native `multiGetObjectsGraphql`.
  */
 
-import {
-  getJsonRpcFullnodeUrl,
-  MultiGetObjectsParams,
-  SuiJsonRpcClient,
-  SuiObjectResponse,
-} from "@mysten/sui/jsonRpc";
-import { getConfEnv } from "./ids.js";
+import { multiGetObjectsGraphql, type FlatObject } from "./blockchain.js";
 
-export { multiGetObjectsGraphql, type FlatObject } from "./blockchain.js";
-
-// Lazy initialization for the SuiClient instance
-let suiClientInstance: SuiJsonRpcClient | undefined = undefined;
-let suiNodeUrl: string | undefined = undefined;
+export { multiGetObjectsGraphql, type FlatObject };
 
 /**
- * Get the current Sui node URL.
- * If no URL has been set, it defaults to the mainnet full node URL.
+ * Batch-fetch objects by id.
  *
- * @deprecated The SDK no longer uses JSON-RPC for reads. Use the
- *   GraphQL singleton via `getGraphQLClient()` / `setGraphQLUrl()` for
- *   new code; this accessor is kept for legacy callers.
+ * @deprecated Prefer `multiGetObjectsGraphql(ids)`. This wrapper delegates to
+ *   it (GraphQL) and returns the flat object shape
+ *   `{ objectId, version, digest, type, fields }` — not the old JSON-RPC
+ *   `SuiObjectResponse` shape.
  */
-export function getSuiNodeUrl(): string {
-  suiNodeUrl = suiNodeUrl ? suiNodeUrl : getJsonRpcFullnodeUrl("mainnet");
-  return suiNodeUrl;
-}
-
-/**
- * Get the SuiClient instance.
- * If a new URL has been set via setSuiNodeUrl, it will create a new instance with the updated URL.
- *
- * Still useful internally for `Transaction.build()` and externally for
- * callers that want to sign/execute transactions; the SDK's read paths
- * no longer go through this client.
- */
-export function getSuiClient(rpcNodeUrl?: string): SuiJsonRpcClient {
-  if (rpcNodeUrl) {
-    setSuiNodeUrl(rpcNodeUrl);
-  }
-  if (!suiClientInstance) {
-    const nodeUrl = getSuiNodeUrl();
-    suiClientInstance = new SuiJsonRpcClient({
-      url: nodeUrl,
-      // `network` is derived from the active SDK conf env, while `url` may be a
-      // caller-supplied endpoint. A custom URL MUST point at the same network as
-      // the conf env (`production` -> mainnet, otherwise testnet); passing a
-      // mainnet URL while the conf env is `testing` will mislabel the client.
-      network: getConfEnv() === "production" ? "mainnet" : "testnet",
-    });
-  }
-  return suiClientInstance;
-}
-
-/**
- * Set a new Sui node URL.
- * This will invalidate the current SuiClient instance, ensuring that
- * the next call to getSuiClient returns a new instance with the updated URL.
- *
- * @deprecated GraphQL reads use a separate URL — see `setGraphQLUrl()`.
- *   This setter only affects the legacy SuiClient used for transaction
- *   signing/building.
- *
- * @param rpcNodeUrl - The new RPC URL for the Sui client.
- */
-export function setSuiNodeUrl(rpcNodeUrl: string) {
-  if (suiNodeUrl !== rpcNodeUrl) {
-    suiNodeUrl = rpcNodeUrl;
-    suiClientInstance = undefined; // Invalidate the current instance to allow creating a new one
-  }
-}
-
-/**
- * Set a new SuiClient instance with the specified RPC node URL.
- *
- * @deprecated See `setSuiNodeUrl` — this setter only affects the legacy
- *   SuiClient used for transaction signing/building. Use
- *   `setGraphQLUrl()` for read endpoints.
- */
-export function setSuiClient(rpcNodeUrl: string) {
-  if (suiNodeUrl !== rpcNodeUrl) {
-    suiNodeUrl = rpcNodeUrl;
-    suiClientInstance = new SuiJsonRpcClient({
-      url: rpcNodeUrl,
-      // See `getSuiClient`: `network` follows the conf env, so a custom
-      // `rpcNodeUrl` must target the matching network.
-      network: getConfEnv() === "production" ? "mainnet" : "testnet",
-    });
-  }
-}
-
-/**
- * Set a custom SuiClient instance.
- *
- * @deprecated See `setSuiNodeUrl` — only the legacy SuiClient is
- *   replaced. Use `setGraphQLUrl()` to point reads at a custom endpoint.
- */
-export const setCustomSuiClient = (suiClient: SuiJsonRpcClient) => {
-  suiClientInstance = suiClient;
-};
-
-/**
- * Batch fetch JSON-RPC `SuiObjectResponse` shapes for the given object ids.
- *
- * @deprecated v0.1.x of the SDK migrated all internal reads to GraphQL.
- *   This helper still uses `SuiClient.multiGetObjects` so existing
- *   callers remain source-compatible. New code should call
- *   `multiGetObjectsGraphql(ids)` (re-exported from this module), which
- *   returns the GraphQL-native flat object shape
- *   `{ objectId, version, digest, type, fields }`.
- */
-export function getMultiObjects(
-  input: MultiGetObjectsParams,
-): Promise<SuiObjectResponse[]> {
-  const suiClient = getSuiClient();
-  return suiClient.multiGetObjects(input);
+export function getMultiObjects(input: {
+  ids: string[];
+}): Promise<(FlatObject | null)[]> {
+  return multiGetObjectsGraphql(input.ids);
 }


### PR DESCRIPTION
- Pins `@mysten/sui` to exactly `2.22.0` — part of aligning the version across FE-bundled packages so the alphafi-fe Docker build stops failing on duplicate-copy `Transaction` type errors.
- Removes the legacy JSON-RPC `SuiClient` singleton and its accessors (`getSuiClient`, `setSuiClient`, `setSuiNodeUrl`, `setCustomSuiClient`, `getSuiNodeUrl`); `getMultiObjects` now delegates to the GraphQL-native `multiGetObjectsGraphql`.
